### PR TITLE
ENH: force_double to control double/single precision of writing data

### DIFF
--- a/pyuff/pyuff.py
+++ b/pyuff/pyuff.py
@@ -284,7 +284,7 @@ class UFF:
             dset = dset[0]
         return dset
 
-    def write_sets(self, dsets, mode='add'):
+    def write_sets(self, dsets, mode='add', force_double=True):
         """
         Writes several UFF data-sets to the file.  The mode can be
         either 'add' (default) or 'overwrite'. The dsets is a
@@ -299,6 +299,13 @@ class UFF:
         data-sets some fields are set automatically. Optional fields are
         calculated automatically and the dset is updated - as dset is actually
         an alias (aka pointer), this is reflected at the caller too.
+
+        The required fields are:
+            dset - dictionary representing the data-set
+            mode - 'add' or 'overwrite'
+            force_double - True or False (default True). Single precision should
+                be avoided, therefore by default data is saved with double 
+                precision.
         """
         if (not type(dsets).__name__ == 'list'):
             dsets = [dsets]
@@ -308,13 +315,13 @@ class UFF:
         if mode.lower() == 'overwrite':
             # overwrite mode; first set is written in the overwrite mode, others
             # in add mode
-            self._write_set(dsets[0], 'overwrite')
+            self._write_set(dsets[0], 'overwrite', force_double=force_double)
             for ii in range(1, n_sets):
-                self._write_set(dsets[ii], 'add')
+                self._write_set(dsets[ii], 'add', force_double=force_double)
         elif mode.lower() == 'add':
             # add mode; all the sets are written in the add mode
             for ii in range(0, n_sets):
-                self._write_set(dsets[ii], 'add')
+                self._write_set(dsets[ii], 'add', force_double=force_double)
         else:
             raise Exception('Unknown mode: ' + mode)
 
@@ -386,7 +393,7 @@ class UFF:
             pass
         return dset
 
-    def _write_set(self, dset, mode='add'):
+    def _write_set(self, dset, mode='add', force_double=True):
         """
         Writes UFF data (UFF data-sets) to the file.  The mode can be
         either 'add' (default) or 'overwrite'. The dset is a
@@ -432,7 +439,7 @@ class UFF:
             elif set_type == 55:
                 _write55(fh, dset)
             elif set_type == 58:
-                _write58(fh, dset, mode, _filename=self._filename)
+                _write58(fh, dset, mode, _filename=self._filename, force_double=force_double)
             elif set_type == 82:
                 _write82(fh, dset)
             elif set_type == 151:

--- a/tests/test_58.py
+++ b/tests/test_58.py
@@ -6,6 +6,7 @@ sys.path.insert(0, my_path + '/../')
 import pyuff
 
 def test_read_write_read_given_data():
+    test_read_write_read_given_data_base('./data/sample_dataset58_psd.uff', force_double=False)
     test_read_write_read_given_data_base('./data/time-history-not-all-columns-filled.uff')
     test_read_write_read_given_data_base('./data/Artemis export - data and dof 05_14102016_105117.uff')
     test_read_write_read_given_data_base('./data/BK_4_channels.uff')
@@ -15,7 +16,7 @@ def test_read_write_read_given_data():
     test_read_write_read_given_data_base('./data/no_spacing2_UFF58_ascii.uff',data_at_the_end)
     test_read_write_read_given_data_base('./data/sample_dataset58_psd.uff')
 
-def test_read_write_read_given_data_base(file='', data_at_the_end=None):
+def test_read_write_read_given_data_base(file='', data_at_the_end=None, force_double=True):
     if file=='':
         return
     #read from file
@@ -31,7 +32,7 @@ def test_read_write_read_given_data_base(file='', data_at_the_end=None):
     if os.path.exists(save_to_file):
         os.remove(save_to_file)
     _ = pyuff.UFF(save_to_file)
-    _.write_sets(a, 'add')
+    _.write_sets(a, 'add', force_double=force_double)
 
     #read back
     uff_read = pyuff.UFF(save_to_file)


### PR DESCRIPTION
When pyuff was initially written, the single precision of dataset 58 was seen as bad practice (and still is today). Due to this it was hard coded that dataset 58 was always written with double_precision. With this PR the single/double precision in dataset 58 is controlled with the parameter force_double which is by default True.