### PR TITLE
Support for dataset 2467; Fix datasets 2412 and 2420

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+!!This is a fork from pyuff with support for dataset 2467. See link for the original library; note that this version can't be installed via pip.
+
+
 pyuff
 =====
 
@@ -5,7 +8,7 @@ Universal File Format read and write
 ------------------------------------
 This module defines an UFF class to manipulate with the UFF (Universal File Format) files.
 
-Read from and write of data-set types **15, 55, 58, 58b, 82, 151, 164, 2411, 2412, 2414, 2420, 2429** are supported.
+Read from and write of data-set types **15, 55, 58, 58b, 82, 151, 164, 2411, 2412, 2414, 2420, 2429, 2467** are supported.
 
 Check out the `documentation <https://pyuff.readthedocs.io/en/latest/index.html>`_.
 

--- a/pyuff/datasets/__init__.py
+++ b/pyuff/datasets/__init__.py
@@ -9,3 +9,4 @@ from .dataset_2412 import prepare_2412
 from .dataset_2414 import prepare_2414
 from .dataset_2420 import prepare_2420
 from .dataset_2429 import prepare_2429, prepare_group
+from .dataset_2467 import prepare_2467

--- a/pyuff/datasets/dataset_2412.py
+++ b/pyuff/datasets/dataset_2412.py
@@ -10,17 +10,26 @@ def _write2412(fh, dset):
             if elt_type == "type":
                 pass
             else:
-                for i in range(len(dset[elt_type]['element_nums'])):
+                #for i in range(len(dset[elt_type]['element_nums'])):
+                for elem in dset['all']:
                     fh.write('%10i%10i%10i%10i%10i%10i\n' % (
-                        dset[elt_type]['element_nums'][i],
-                        dset[elt_type]['fe_descriptor'][i],
-                        dset[elt_type]['phys_table'][i],
-                        dset[elt_type]['mat_table'][i],
-                        dset[elt_type]['color'][i],
-                        elt_type_dict[elt_type],
+                        elem['element_nums'],
+                        elem['fe_descriptor'],
+                        elem['phys_table'],
+                        elem['mat_table'],
+                        elem['color'],
+                        elem[elt_type],
                     ))
-                    for ii in range(elt_type_dict[elt_type]):
-                        fh.write('%10i' % dset[elt_type]['nodes_nums'][i][ii])
+                    if elem['f_descriptor'] == 11:
+                    # rods have to be written in 3 lines
+                        fh.write('%10i%10i%10i\n' % (
+                            elem['beam_orientation'],
+                            elem['beam_foreend_cross'],
+                            elem['beam_aftend_cross']
+                        ))
+                    for ii in elem['nodes_nums']:
+                        #fh.write('%10i' % dset[elt_type]['nodes_nums'][i][ii])
+                        fh.write(' '.join(elem))
                     fh.write('\n')
         fh.write('%6i\n' % -1)
 
@@ -30,7 +39,7 @@ def _write2412(fh, dset):
 
 def _extract2412(block_data):
     """Extract element data - data-set 2412."""
-    dset = {'type': 2412}
+    dset = {'type': 2412, 'all': None}
     # Define dictionary of possible elements types
     # Only 2D non-quadratic elements are supported
     elt_type_dict = {'3': 'triangle', '4': 'quad'}
@@ -44,10 +53,8 @@ def _extract2412(block_data):
         dataset = []
         i = 0
         while i < len(split_data):
-            print(f"Starting loop with i={i}")
             dict_tmp = dict()
             line = split_data[i]
-            print(f"line={line}")
             dict_tmp['element_num'] = int(line[0])
             dict_tmp['f_descriptor'] = int(line[1])
             dict_tmp['phys_table'] = int(line[2])
@@ -70,6 +77,7 @@ def _extract2412(block_data):
                 dset[desc] = []
             dset[desc].append(dict_tmp)
             dataset.append(dict_tmp)
+        dset['all'] = dataset
         return dset
         #test = [e['f_descriptor'] for e in dataset]
         #test = set(test)

--- a/pyuff/datasets/dataset_2412.py
+++ b/pyuff/datasets/dataset_2412.py
@@ -6,31 +6,31 @@ def _write2412(fh, dset):
     try:
         elt_type_dict = {'triangle': 3, 'quad': 4}
         fh.write('%6i\n%6i%74s\n' % (-1, 2412, ' '))
-        for elt_type in dset:
-            if elt_type == "type":
-                pass
-            else:
+        #for elt_type in dset:
+        #    if elt_type == "type":
+        #        pass
+        #    else:
                 #for i in range(len(dset[elt_type]['element_nums'])):
-                for elem in dset['all']:
-                    fh.write('%10i%10i%10i%10i%10i%10i\n' % (
-                        elem['element_nums'],
-                        elem['fe_descriptor'],
-                        elem['phys_table'],
-                        elem['mat_table'],
-                        elem['color'],
-                        elem[elt_type],
-                    ))
-                    if elem['f_descriptor'] == 11:
-                    # rods have to be written in 3 lines
-                        fh.write('%10i%10i%10i\n' % (
-                            elem['beam_orientation'],
-                            elem['beam_foreend_cross'],
-                            elem['beam_aftend_cross']
-                        ))
-                    for ii in elem['nodes_nums']:
-                        #fh.write('%10i' % dset[elt_type]['nodes_nums'][i][ii])
-                        fh.write(' '.join(elem))
-                    fh.write('\n')
+        for elem in dset['all']:
+            fh.write('%10i%10i%10i%10i%10i%10i\n' % (
+                elem['element_num'],
+                elem['f_descriptor'],
+                elem['phys_table'],
+                elem['mat_table'],
+                elem['color'],
+                elem['num_nodes'],
+            ))
+            if elem['f_descriptor'] == 11:
+            # rods have to be written in 3 lines
+                fh.write('%10i%10i%10i\n' % (
+                    elem['beam_orientation'],
+                    elem['beam_foreend_cross'],
+                    elem['beam_aftend_cross']
+                ))
+            for ii in elem['nodes_nums']:
+                #fh.write('%10i' % dset[elt_type]['nodes_nums'][i][ii])
+                fh.write(' '.join(elem))
+            fh.write('\n')
         fh.write('%6i\n' % -1)
 
     except:

--- a/pyuff/datasets/dataset_2412.py
+++ b/pyuff/datasets/dataset_2412.py
@@ -6,11 +6,7 @@ def _write2412(fh, dset):
     try:
         elt_type_dict = {'triangle': 3, 'quad': 4}
         fh.write('%6i\n%6i%74s\n' % (-1, 2412, ' '))
-        #for elt_type in dset:
-        #    if elt_type == "type":
-        #        pass
-        #    else:
-                #for i in range(len(dset[elt_type]['element_nums'])):
+
         for elem in dset['all']:
             fh.write('%10i%10i%10i%10i%10i%10i\n' % (
                 elem['element_num'],
@@ -28,9 +24,7 @@ def _write2412(fh, dset):
                     elem['beam_aftend_cross']
                 ))
             for ii in elem['nodes_nums']:
-                #fh.write('%10i' % dset[elt_type]['nodes_nums'][i][ii])
                 fh.write('%10i' % ii)
-                #fh.write(' '.join([str(e) for e in elem['nodes_nums']]))
             fh.write('\n')
         fh.write('%6i\n' % -1)
 
@@ -42,7 +36,6 @@ def _extract2412(block_data):
     """Extract element data - data-set 2412."""
     dset = {'type': 2412, 'all': None}
     # Define dictionary of possible elements types
-    # Only 2D non-quadratic elements are supported
     elt_type_dict = {'3': 'triangle', '4': 'quad'}
     # Read data
     try:
@@ -80,43 +73,7 @@ def _extract2412(block_data):
             dataset.append(dict_tmp)
         dset['all'] = dataset
         return dset
-        #test = [e['f_descriptor'] for e in dataset]
-        #test = set(test)
-        #test = list(test)
-        desc_list = [e['f_descriptor'] for e in dataset]
-        elts_types = list(set(desc_list))
-        for elt_type in elts_types:
-            ind = list(np.where(np.array(desc_list) == elt_type)[0])
-            dict_tmp = dict()
-            #test = [e for dataset if ]    #dataset[ind]
-            test = dataset[ind]
-            dict_tmp['element_nums'] = [e['element_num'] for e in dataset[ind]]#]dataset[ind]['element_num'].copy()
-            dict_tmp['fe_descriptor'] = dataset[ind, 'fe_descriptor'].copy()
-            dict_tmp['phys_table'] = dataset[ind, 'phys_table'].copy()
-            dict_tmp['mat_table'] = dataset[ind, 'mat_table'].copy()
-            dict_tmp['color'] = dataset[ind, 'color'].copy()
-            #dict_tmp['nodes_nums'] = np.array([rec2[i] for i in ind], dtype=int).copy().reshape((-1, elt_type))
-            dict_tmp['nodes_nums'] = dataset[ind, 'color'].copy()
-            #dset[elt_type_dict[str(elt_type)]] = dict_tmp
-            dset[elt_type] = dict_tmp
-        return dataset
 
-
-        #rec1 = np.array(split_data[::2], dtype=int)
-        # Extract Record 2
-        #rec2 = split_data[1::2]
-        # Look for the different types of elements stored in the dataset
-        elts_types = list(set(rec1[:,5]))
-        for elt_type in elts_types:
-            ind = np.where(np.array(rec1[:,5]) == elt_type)[0]
-            dict_tmp = dict()
-            dict_tmp['element_nums'] = rec1[ind,0].copy()
-            dict_tmp['fe_descriptor'] = rec1[ind,1].copy()
-            dict_tmp['phys_table'] = rec1[ind,2].copy()
-            dict_tmp['mat_table'] = rec1[ind,3].copy()
-            dict_tmp['color'] = rec1[ind,4].copy()
-            dict_tmp['nodes_nums'] =  np.array([rec2[i] for i in ind], dtype=int).copy().reshape((-1,elt_type))
-            dset[elt_type_dict[str(elt_type)]] = dict_tmp
     except:
         raise Exception('Error reading data-set #2412')
     return dset
@@ -198,6 +155,9 @@ def prepare_2412(
         'mat_table': mat_table,
         'color': color,
         'num_nodes': num_nodes,
+        'beam_orientation': beam_orientation,
+        'beam_foreend_cross': beam_foreend_cross,
+        'beam_aftend_cross': beam_aftend_cross,
         'nodes_nums': nodes_nums
         }
     

--- a/pyuff/datasets/dataset_2412.py
+++ b/pyuff/datasets/dataset_2412.py
@@ -29,7 +29,8 @@ def _write2412(fh, dset):
                 ))
             for ii in elem['nodes_nums']:
                 #fh.write('%10i' % dset[elt_type]['nodes_nums'][i][ii])
-                fh.write(' '.join(elem))
+                fh.write('%10i' % ii)
+                #fh.write(' '.join([str(e) for e in elem['nodes_nums']]))
             fh.write('\n')
         fh.write('%6i\n' % -1)
 

--- a/pyuff/datasets/dataset_2412.py
+++ b/pyuff/datasets/dataset_2412.py
@@ -44,26 +44,52 @@ def _extract2412(block_data):
         dataset = []
         i = 0
         while i < len(split_data):
+            print(f"Starting loop with i={i}")
             dict_tmp = dict()
             line = split_data[i]
-            dict_tmp['element_num'] = line[0]
-            dict_tmp['f_descriptor'] = line[1]
-            dict_tmp['phys_table'] = line[2]
-            dict_tmp['mat_table'] = line[3]
-            dict_tmp['color'] = line[4]
-            dict_tmp['num_nodes'] = line[5]
+            print(f"line={line}")
+            dict_tmp['element_num'] = int(line[0])
+            dict_tmp['f_descriptor'] = int(line[1])
+            dict_tmp['phys_table'] = int(line[2])
+            dict_tmp['mat_table'] = int(line[3])
+            dict_tmp['color'] = int(line[4])
+            dict_tmp['num_nodes'] = int(line[5])
             if dict_tmp['f_descriptor'] == 11:
                 # element is a rod and covers 3 lines
-                dict_tmp['beam_orientation'] = split_data[i+1][0]
-                dict_tmp['beam_foreend_cross'] = split_data[i + 1][1]
-                dict_tmp['beam_aftend_cross'] = split_data[i + 1][2]
-                dict_tmp['nodes_nums'] = split_data[i + 2]
+                dict_tmp['beam_orientation'] = int(split_data[i+1][0])
+                dict_tmp['beam_foreend_cross'] = int(split_data[i + 1][1])
+                dict_tmp['beam_aftend_cross'] = int(split_data[i + 1][2])
+                dict_tmp['nodes_nums'] = [int(e) for e in split_data[i+2]]
                 i += 3
             else:
                 # element is no rod and covers 2 lines
-                dict_tmp['nodes_nums'] = split_data[i + 1]
+                dict_tmp['nodes_nums'] = [int(e) for e in split_data[i+1]]
                 i += 2
+            desc = dict_tmp['f_descriptor']
+            if not desc in dset:
+                dset[desc] = []
+            dset[desc].append(dict_tmp)
             dataset.append(dict_tmp)
+        return dset
+        #test = [e['f_descriptor'] for e in dataset]
+        #test = set(test)
+        #test = list(test)
+        desc_list = [e['f_descriptor'] for e in dataset]
+        elts_types = list(set(desc_list))
+        for elt_type in elts_types:
+            ind = list(np.where(np.array(desc_list) == elt_type)[0])
+            dict_tmp = dict()
+            #test = [e for dataset if ]    #dataset[ind]
+            test = dataset[ind]
+            dict_tmp['element_nums'] = [e['element_num'] for e in dataset[ind]]#]dataset[ind]['element_num'].copy()
+            dict_tmp['fe_descriptor'] = dataset[ind, 'fe_descriptor'].copy()
+            dict_tmp['phys_table'] = dataset[ind, 'phys_table'].copy()
+            dict_tmp['mat_table'] = dataset[ind, 'mat_table'].copy()
+            dict_tmp['color'] = dataset[ind, 'color'].copy()
+            #dict_tmp['nodes_nums'] = np.array([rec2[i] for i in ind], dtype=int).copy().reshape((-1, elt_type))
+            dict_tmp['nodes_nums'] = dataset[ind, 'color'].copy()
+            #dset[elt_type_dict[str(elt_type)]] = dict_tmp
+            dset[elt_type] = dict_tmp
         return dataset
 
 

--- a/pyuff/datasets/dataset_2420.py
+++ b/pyuff/datasets/dataset_2420.py
@@ -53,12 +53,9 @@ def _extract2420(block_data):
     row2 = list(map(float, ''.join(split_data[7::6]).split()))
     row3 = list(map(float, ''.join(split_data[8::6]).split()))
     row4 = list(map(float, ''.join(split_data[9::6]).split()))
-    # !! Row 4 left out for now - usually zeros ...
-    #            row4 = map(float, split_data[7::6].split())
     dset['CS_matrices'] = [np.vstack((row1[i:(i + 3)], row2[i:(i + 3)], row3[i:(i + 3)], row4[i:(i + 3)])) \
                             for i in np.arange(0, len(row1), 3)]
-    #        except:
-    #            raise Exception('Error reading data-set #2420')
+
     return dset
 
 

--- a/pyuff/datasets/dataset_2420.py
+++ b/pyuff/datasets/dataset_2420.py
@@ -17,13 +17,14 @@ def _write2420(fh, dset):
         fh.write('%10i\n' % (dset['part_UID']))
         fh.write('%-80s\n' % (dset['part_name']))
 
-        for node in range(len(dset['nodes'])):
-            fh.write('%10i%10i%10i\n' % (dset['nodes'][node], dset['cs_type'], dset['cs_color']))
-            fh.write('CS%i\n' % dset['nodes'][node])
-            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['local_cs'][node * 4, :]))
-            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['local_cs'][node * 4 + 1, :]))
-            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['local_cs'][node * 4 + 2, :]))
-            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['local_cs'][node * 4 + 3, :]))
+        num_CS = min( (len(dset['CS_sys_labels']),  len(dset['CS_types']),  len(dset['CS_colors']),  len(dset['CS_names']), len(dset['CS_matrices'])) )
+        for node in range(num_CS):
+            fh.write('%10i%10i%10i\n' % (dset['CS_sys_labels'][node], dset['CS_types'][node], dset['CS_colors'][node]))
+            fh.write('%s\n' % dset['CS_names'][node])
+            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][0, :]))
+            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][1, :]))
+            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][2, :]))
+            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][3, :]))
         fh.write('%6i\n' % -1)
     except:
         raise Exception('Error writing data-set #2420')
@@ -54,9 +55,10 @@ def _extract2420(block_data):
     row1 = list(map(float, ''.join(split_data[6::6]).split()))
     row2 = list(map(float, ''.join(split_data[7::6]).split()))
     row3 = list(map(float, ''.join(split_data[8::6]).split()))
+    row4 = list(map(float, ''.join(split_data[9::6]).split()))
     # !! Row 4 left out for now - usually zeros ...
     #            row4 = map(float, split_data[7::6].split())
-    dset['CS_matrices'] = [np.vstack((row1[i:(i + 3)], row2[i:(i + 3)], row3[i:(i + 3)])) \
+    dset['CS_matrices'] = [np.vstack((row1[i:(i + 3)], row2[i:(i + 3)], row3[i:(i + 3)], row4[i:(i + 3)])) \
                             for i in np.arange(0, len(row1), 3)]
     #        except:
     #            raise Exception('Error reading data-set #2420')

--- a/pyuff/datasets/dataset_2420.py
+++ b/pyuff/datasets/dataset_2420.py
@@ -2,9 +2,6 @@ import numpy as np
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
 
-# TODO: Big deal - the output dictionary when reading this set
-#    is different than the dictionary that is expected (keys) when
-#    writing this same set. This is not OK!
 def _write2420(fh, dset):
     try:
         dict = {'part_UID': 1,

--- a/pyuff/datasets/dataset_2467.py
+++ b/pyuff/datasets/dataset_2467.py
@@ -1,0 +1,189 @@
+import numpy as np
+
+from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
+
+# TODO: Big deal - the output dictionary when reading this set
+#    is different than the dictionary that is expected (keys) when
+#    writing this same set. This is not OK!
+def _write2467(fh, dset):
+    try:
+        dict = {'part_UID': 1,
+                'part_name': 'None',
+                'cs_type': 0,
+                'cs_color': 8}
+        dset = _opt_fields(dset, dict)
+
+        fh.write('%6i\n%6i%74s\n' % (-1, 2420, ' '))
+        fh.write('%10i\n' % (dset['part_UID']))
+        fh.write('%-80s\n' % (dset['part_name']))
+
+        num_CS = min( (len(dset['CS_sys_labels']),  len(dset['CS_types']),  len(dset['CS_colors']),  len(dset['CS_names']), len(dset['CS_matrices'])) )
+        for node in range(num_CS):
+            fh.write('%10i%10i%10i\n' % (dset['CS_sys_labels'][node], dset['CS_types'][node], dset['CS_colors'][node]))
+            fh.write('%s\n' % dset['CS_names'][node])
+            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][0, :]))
+            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][1, :]))
+            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][2, :]))
+            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][3, :]))
+        fh.write('%6i\n' % -1)
+    except:
+        raise Exception('Error writing data-set #2467')
+
+def _extract2467(block_data):
+    '''Extract local CS/transforms -- data-set 2467.'''
+    dset = {'type': 2467}
+    #        try:
+    split_data = block_data.splitlines(True)
+
+    # -- Get Record 1
+    dset['Part_UID'] = float(split_data[2])
+
+    # -- Get Record 2
+    dset['Part_Name'] = split_data[3].rstrip()
+
+    # -- Get Record 3
+    rec_3 = list(map(int, ''.join(split_data[4::6]).split()))
+    dset['CS_sys_labels'] = rec_3[::3]
+    dset['CS_types'] = rec_3[1::3]
+    dset['CS_colors'] = rec_3[2::3]
+
+    # -- Get Record 4
+    dset['CS_names'] = list(map(str.rstrip, split_data[5::6]))
+
+    # !! The following part should be made smoother
+    # -- Get Record 5
+    row1 = list(map(float, ''.join(split_data[6::6]).split()))
+    row2 = list(map(float, ''.join(split_data[7::6]).split()))
+    row3 = list(map(float, ''.join(split_data[8::6]).split()))
+    row4 = list(map(float, ''.join(split_data[9::6]).split()))
+    # !! Row 4 left out for now - usually zeros ...
+    #            row4 = map(float, split_data[7::6].split())
+    dset['CS_matrices'] = [np.vstack((row1[i:(i + 3)], row2[i:(i + 3)], row3[i:(i + 3)], row4[i:(i + 3)])) \
+                            for i in np.arange(0, len(row1), 3)]
+    #        except:
+    #            raise Exception('Error reading data-set #2467')
+    return dset
+
+
+def prepare_2467(
+        group_ids=None,
+        constraint_sets=None,
+        restraint_sets=None,
+        load_sets=None,
+        dof_sets=None,
+        temp_sets=None,
+        contact_sets=None,
+        num_entities=None,
+        group_names=None,
+        ent_types=None,
+        ent_tags=None,
+        ent_node_ids=None,
+        ent_comp_ids=None,
+        return_full_dict=False):
+    """Name: Coordinate Systems
+
+    R-Record, F-Field
+
+    :param group_id: R1 F1, group ID
+    :param constraint_sets: R1 F2, active group constraint set no.
+    :param restraint_sets: R1 F3, active group restraint set no.
+    :param load_sets: R1 F4, active group load set no.
+    :param dof_sets: R1 F5, active group dof set no.
+    :param temp_sets: R1 F6, active group temperature set no.
+    :param contact_sets: R1 F7, active group contact set no.
+    :param num_entities: R1 F8, number of entities in group
+    :param group_names: R2 F1, group Name
+    :param ent_types: R3 F1(F5), entity type code
+    :param ent_tags: R3 F2(F6), entity tag
+    :param ent_node_ids: R3 F3(F7), entity type code
+    :param ent_comp_ids: R3 F4(F8), entity component / ham id
+    :param return_full_dict: If True full dict with all keys is returned, else only specified arguments are included
+
+    Records 1-2 are repeated for each node in the model, followed by a specified number (R1F8) of Record 3's.
+    """
+    # **Test prepare_2467**
+    #save_to_file = 'test_pyuff'
+    #dataset = pyuff.prepare_2467(
+    #    Part_UID = 1,
+    #    Part_Name = 'None',
+    #    CS_sys_labels = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    #    CS_types = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    #    CS_colors = [8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+    #    CS_names = ['CS1', 'CS2', 'CS3', 'CS4', 'CS5', 'CS6', 'CS7', 'CS8', 'CS9', 'CS10'],
+    #    CS_matrices = [np.array([[-0.44807362, 0., 0.89399666], [-0., 1., 0.], [-0.89399666, -0., -0.44807362]]),
+    #                    np.array([[-0.44807362,  0.,  0.89399666], [-0.,  1.,  0.], [-0.89399666, -0., -0.44807362]]),
+    #                    np.array([[-0.44807362,  0.,  0.89399666], [-0.,  1.,  0.], [-0.89399666, -0., -0.44807362]]),
+    #                    np.array([[-0.44807362,  0.,  0.89399666], [-0.,  1., 0.], [-0.89399666, -0., -0.44807362]]),
+    #                    np.array([[-0.44807362,  0.,  0.89399666], [-0., 1., 0.], [-0.89399666, -0., -0.44807362]]),
+    #                    np.array([[-0.44807362,  0.,  0.89399666], [-0., 1., 0.], [-0.89399666, -0., -0.44807362]]),
+    #                    np.array([[-0.44807362,  0.,  0.89399666], [-0., 1., 0.], [-0.89399666, -0., -0.44807362]]),
+    #                    np.array([[-0.44807362,  0.,  0.89399666], [-0., 1., 0.], [-0.89399666, -0., -0.44807362]]),
+    #                    np.array([[-0.44807362,  0.,  0.89399666], [-0., 1., 0.], [-0.89399666, -0., -0.44807362]]),
+    #                    np.array([[-0.44807362,  0.,  0.89399666], [-0., 1., 0.], [-0.89399666, -0., -0.44807362]])])
+    #if save_to_file:
+    #    if os.path.exists(save_to_file):
+    #        os.remove(save_to_file)
+    #    uffwrite = pyuff.UFF(save_to_file)
+    #    uffwrite.write_sets(dataset, mode='add')
+    #dataset
+
+    if np.array(group_ids).dtype != int and group_ids != None:
+        raise TypeError('group_ids must be integer')
+    if np.array(constraint_sets).dtype != int and constraint_sets != None:
+        raise ValueError('constraint_sets must be integer')
+    if np.array(restraint_sets).dtype != int and restraint_sets != None:
+        raise TypeError('restraint_sets must be integer')
+    if np.array(load_sets).dtype != int and load_sets != None:
+        raise ValueError('load_sets must be integer')
+    if np.array(dof_sets).dtype != int and dof_sets != None:
+        raise TypeError('dof_sets must be integer')
+    if np.array(temp_sets).dtype != int and temp_sets != None:
+        raise ValueError('temp_sets must be integer')
+    if np.array(contact_sets).dtype != int and contact_sets != None:
+        raise TypeError('contact_sets must be integer')
+    if np.array(num_entities).dtype != int and num_entities != None:
+        raise ValueError('num_entities must be integer')
+    if np.array(group_names).dtype != str and group_names != None:
+        raise TypeError('group_names must be str')
+    if type(group_names) == np.ndarray or type(group_names) == list:
+        for i in group_names:
+            if type(i) != np.str_:
+                raise TypeError('group_names datatype must be str')
+    if np.array(ent_types).dtype != int and ent_types != None:
+        raise ValueError('ent_types must be integer')
+    if np.array(ent_tags).dtype != int and ent_tags != None:
+        raise ValueError('ent_tags must be integer')
+    if np.array(ent_node_ids).dtype != int and ent_node_ids != None:
+        raise ValueError('ent_node_ids must be integer')
+    if np.array(ent_comp_ids).dtype != int and ent_comp_ids != None:
+        raise ValueError('ent_comp_ids must be integer')
+
+    #if type(CS_types) in (np.ndarray, list, tuple):
+    #    for i in CS_types:
+    #        if i not in (0, 1, 2):
+    #            raise ValueError('CS_types can be 0, 1, 2')
+
+
+
+    dataset={
+        'type': 2467,
+        'group_ids': group_ids,
+        'constraint_sets': constraint_sets,
+        'restraint_sets': restraint_sets,
+        'load_sets': load_sets,
+        'dof_sets': dof_sets,
+        'temp_sets': temp_sets,
+        'contact_sets': contact_sets,
+        'num_entities': num_entities,
+        'group_names': group_names,
+        'ent_types': ent_types,
+        'ent_tags': ent_tags,
+        'ent_node_ids': ent_node_ids,
+        'ent_comp_ids': ent_comp_ids,
+        }
+
+    if return_full_dict is False:
+        dataset = check_dict_for_none(dataset)
+
+    return dataset
+

--- a/pyuff/datasets/dataset_2467.py
+++ b/pyuff/datasets/dataset_2467.py
@@ -7,24 +7,43 @@ from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
 #    writing this same set. This is not OK!
 def _write2467(fh, dset):
     try:
-        dict = {'part_UID': 1,
-                'part_name': 'None',
-                'cs_type': 0,
-                'cs_color': 8}
-        dset = _opt_fields(dset, dict)
+        #dict = {'part_UID': 1,
+        #        'part_name': 'None',
+        #        'cs_type': 0,
+        #        'cs_color': 8}
+        #dset = _opt_fields(dset, dict)
 
-        fh.write('%6i\n%6i%74s\n' % (-1, 2420, ' '))
-        fh.write('%10i\n' % (dset['part_UID']))
-        fh.write('%-80s\n' % (dset['part_name']))
+        # = None,
+        # = None,
+        # = None,
+        # = None,
+        # = None,
+        #return_full_dict = False):
 
-        num_CS = min( (len(dset['CS_sys_labels']),  len(dset['CS_types']),  len(dset['CS_colors']),  len(dset['CS_names']), len(dset['CS_matrices'])) )
-        for node in range(num_CS):
-            fh.write('%10i%10i%10i\n' % (dset['CS_sys_labels'][node], dset['CS_types'][node], dset['CS_colors'][node]))
-            fh.write('%s\n' % dset['CS_names'][node])
-            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][0, :]))
-            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][1, :]))
-            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][2, :]))
-            fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][3, :]))
+        fh.write('%6i\n%6i%74s\n' % (-1, 2467, ' '))
+
+
+
+
+        #num_CS = min( (len(dset['CS_sys_labels']),  len(dset['CS_types']),  len(dset['CS_colors']),  len(dset['CS_names']), len(dset['CS_matrices'])) )
+        for i in range(len(dset['group_ids'])):
+            fh.write('%10i%10i%10i%10i%10i%10i%10i%10i\n' % (dset['group_ids'][i], dset['constraint_sets'][i], dset['restraint_sets'][i], dset['load_sets'][i], dset['dof_sets'][i], dset['temp_sets'][i], dset['contact_sets'][i], dset['num_entities'][i]))
+            fh.write('%-80s\n' % (dset['group_names'][i]))
+
+            ii = 0
+            while ii < dset['num_entities'][i]:
+                if dset['num_entities'][i] - ii > 1:
+                    fh.write('%10i%10i%10i%10i%10i%10i%10i%10i\n' % (dset['ent_types'][i][ii], dset['ent_tags'][i][ii], dset['ent_node_ids'][i][ii], dset['ent_comp_ids'][i][ii], dset['ent_types'][i][ii+1], dset['ent_tags'][i][ii+1], dset['ent_node_ids'][i][ii+1], dset['ent_comp_ids'][i][ii+1]))
+                    ii += 2
+                else:
+                    fh.write('%10i%10i%10i%10i\n' % (dset['ent_types'][i][ii], dset['ent_tags'][i][ii], dset['ent_node_ids'][i][ii], dset['ent_comp_ids'][i][ii]))
+                    ii += 1
+            #fh.write('%10i%10i%10i\n' % (dset['CS_sys_labels'][node], dset['CS_types'][node], dset['CS_colors'][node]))
+            #fh.write('%s\n' % dset['CS_names'][node])
+            #fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][0, :]))
+            #fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][1, :]))
+            #fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][2, :]))
+            #fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][3, :]))
         fh.write('%6i\n' % -1)
     except:
         raise Exception('Error writing data-set #2467')
@@ -74,20 +93,20 @@ def _extract2467(block_data):
         while left_entities:
             line = split_data[i]
             if len(line) == 8:
-                ent_types[index].append(line[0])
-                ent_tags[index].append(line[1])
-                ent_node_ids[index].append(line[2])
-                ent_comp_ids[index].append(line[3])
-                ent_types[index].append(line[4])
-                ent_tags[index].append(line[5])
-                ent_node_ids[index].append(line[6])
-                ent_comp_ids[index].append(line[7])
+                ent_types[index].append(int(line[0]))
+                ent_tags[index].append(int(line[1]))
+                ent_node_ids[index].append(int(line[2]))
+                ent_comp_ids[index].append(int(line[3]))
+                ent_types[index].append(int(line[4]))
+                ent_tags[index].append(int(line[5]))
+                ent_node_ids[index].append(int(line[6]))
+                ent_comp_ids[index].append(int(line[7]))
                 left_entities -= 2
             elif len(line) == 4:
-                ent_types[index].append(line[0])
-                ent_tags[index].append(line[1])
-                ent_node_ids[index].append(line[2])
-                ent_comp_ids[index].append(line[3])
+                ent_types[index].append(int(line[0]))
+                ent_tags[index].append(int(line[1]))
+                ent_node_ids[index].append(int(line[2]))
+                ent_comp_ids[index].append(int(line[3]))
                 left_entities -= 1
             else:
                 raise Exception("R3 of dataset 2467 needs to contain 4 or 8 values")

--- a/pyuff/datasets/dataset_2467.py
+++ b/pyuff/datasets/dataset_2467.py
@@ -32,36 +32,69 @@ def _write2467(fh, dset):
 def _extract2467(block_data):
     '''Extract local CS/transforms -- data-set 2467.'''
     dset = {'type': 2467}
-    #        try:
     split_data = block_data.splitlines(True)
+    split_data = [a.split() for a in split_data][2:]
 
-    # -- Get Record 1
-    dset['Part_UID'] = float(split_data[2])
+    group_ids = []
+    constraint_sets = []
+    restraint_sets = []
+    load_sets = []
+    dof_sets = []
+    temp_sets = []
+    contact_sets = []
+    num_entities = []
+    group_names = []
 
-    # -- Get Record 2
-    dset['Part_Name'] = split_data[3].rstrip()
+    ent_types = []
+    ent_tags = []
+    ent_node_ids = []
+    ent_comp_ids = []
 
-    # -- Get Record 3
-    rec_3 = list(map(int, ''.join(split_data[4::6]).split()))
-    dset['CS_sys_labels'] = rec_3[::3]
-    dset['CS_types'] = rec_3[1::3]
-    dset['CS_colors'] = rec_3[2::3]
+    i = 0
+    index = 0
+    while i < len(split_data):
+        group_ids.append(int(split_data[i][0]))
+        constraint_sets.append(int(split_data[i][1]))
+        restraint_sets.append(int(split_data[i][2]))
+        load_sets.append(int(split_data[i][3]))
+        dof_sets.append(int(split_data[i][4]))
+        temp_sets.append(int(split_data[i][5]))
+        contact_sets.append(int(split_data[i][6]))
+        left_entities = int(split_data[i][7])
+        num_entities.append(left_entities)
 
-    # -- Get Record 4
-    dset['CS_names'] = list(map(str.rstrip, split_data[5::6]))
+        group_names.append(str(split_data[i+1][0]))
 
-    # !! The following part should be made smoother
-    # -- Get Record 5
-    row1 = list(map(float, ''.join(split_data[6::6]).split()))
-    row2 = list(map(float, ''.join(split_data[7::6]).split()))
-    row3 = list(map(float, ''.join(split_data[8::6]).split()))
-    row4 = list(map(float, ''.join(split_data[9::6]).split()))
-    # !! Row 4 left out for now - usually zeros ...
-    #            row4 = map(float, split_data[7::6].split())
-    dset['CS_matrices'] = [np.vstack((row1[i:(i + 3)], row2[i:(i + 3)], row3[i:(i + 3)], row4[i:(i + 3)])) \
-                            for i in np.arange(0, len(row1), 3)]
-    #        except:
-    #            raise Exception('Error reading data-set #2467')
+        ent_types.append([])
+        ent_tags.append([])
+        ent_node_ids.append([])
+        ent_comp_ids.append([])
+
+        i += 2
+        while left_entities:
+            line = split_data[i]
+            if len(line) == 8:
+                ent_types[index].append(line[0])
+                ent_tags[index].append(line[1])
+                ent_node_ids[index].append(line[2])
+                ent_comp_ids[index].append(line[3])
+                ent_types[index].append(line[4])
+                ent_tags[index].append(line[5])
+                ent_node_ids[index].append(line[6])
+                ent_comp_ids[index].append(line[7])
+                left_entities -= 2
+            elif len(line) == 4:
+                ent_types[index].append(line[0])
+                ent_tags[index].append(line[1])
+                ent_node_ids[index].append(line[2])
+                ent_comp_ids[index].append(line[3])
+                left_entities -= 1
+            else:
+                raise Exception("R3 of dataset 2467 needs to contain 4 or 8 values")
+            i += 1
+        index += 1
+
+    dset.update({'group_ids': group_ids, 'constraint_sets': constraint_sets, 'restraint_sets': restraint_sets, 'load_sets': load_sets, 'dof_sets': dof_sets, 'temp_sets': temp_sets, 'contact_sets': contact_sets, 'num_entities': num_entities, 'group_names': group_names, 'ent_types': ent_types, 'ent_tags': ent_tags, 'ent_node_ids': ent_node_ids, 'ent_comp_ids': ent_comp_ids})
     return dset
 
 

--- a/pyuff/datasets/dataset_2467.py
+++ b/pyuff/datasets/dataset_2467.py
@@ -2,9 +2,6 @@ import numpy as np
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
 
-# TODO: Big deal - the output dictionary when reading this set
-#    is different than the dictionary that is expected (keys) when
-#    writing this same set. This is not OK!
 def _write2467(fh, dset):
     try:
         #dict = {'part_UID': 1,
@@ -38,18 +35,12 @@ def _write2467(fh, dset):
                 else:
                     fh.write('%10i%10i%10i%10i\n' % (dset['ent_types'][i][ii], dset['ent_tags'][i][ii], dset['ent_node_ids'][i][ii], dset['ent_comp_ids'][i][ii]))
                     ii += 1
-            #fh.write('%10i%10i%10i\n' % (dset['CS_sys_labels'][node], dset['CS_types'][node], dset['CS_colors'][node]))
-            #fh.write('%s\n' % dset['CS_names'][node])
-            #fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][0, :]))
-            #fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][1, :]))
-            #fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][2, :]))
-            #fh.write('%25.16e%25.16e%25.16e\n' % tuple(dset['CS_matrices'][node][3, :]))
         fh.write('%6i\n' % -1)
     except:
         raise Exception('Error writing data-set #2467')
 
 def _extract2467(block_data):
-    '''Extract local CS/transforms -- data-set 2467.'''
+    '''Extract physical groups -- data-set 2467.'''
     dset = {'type': 2467}
     split_data = block_data.splitlines(True)
     split_data = [a.split() for a in split_data][2:]
@@ -209,13 +200,6 @@ def prepare_2467(
         raise ValueError('ent_node_ids must be integer')
     if np.array(ent_comp_ids).dtype != int and ent_comp_ids != None:
         raise ValueError('ent_comp_ids must be integer')
-
-    #if type(CS_types) in (np.ndarray, list, tuple):
-    #    for i in CS_types:
-    #        if i not in (0, 1, 2):
-    #            raise ValueError('CS_types can be 0, 1, 2')
-
-
 
     dataset={
         'type': 2467,

--- a/pyuff/pyuff.py
+++ b/pyuff/pyuff.py
@@ -25,7 +25,7 @@ defines an UFF class to manipulate with the
 UFF (Universal File Format) files, i.e., to read from and write
 to UFF files. Among the variety of UFF formats, only some of the
 formats (data-set types) frequently used in structural dynamics
-are supported: **15, 55, 58, 58b, 82, 151, 164, 2411, 2412, 2414, 2420, 2429** Data-set **58b**
+are supported: **15, 55, 58, 58b, 82, 151, 164, 2411, 2412, 2414, 2420, 2429, 2467** Data-set **58b**
 is actually a hybrid format [1]_ where the signal is written in the
 binary form, while the header-part is slightly different from 58 but still in the
 ascii format.
@@ -459,6 +459,8 @@ class UFF:
                 _write2420(fh, dset)
             elif set_type == 2429:
                 _write2429(fh, dset)
+            elif set_type == 2467:
+                _write2467(fh, dset)
             else:
                 # Unsupported data-set - do nothing
                 pass

--- a/pyuff/pyuff.py
+++ b/pyuff/pyuff.py
@@ -77,8 +77,9 @@ from .datasets.dataset_2412 import _write2412, _extract2412
 from .datasets.dataset_2414 import _write2414, _extract2414
 from .datasets.dataset_2420 import _write2420, _extract2420
 from .datasets.dataset_2429 import _write2429, _extract2429
+from .datasets.dataset_2467 import _write2467, _extract2467
 
-_SUPPORTED_SETS = ['15', '55', '58', '58b', '82', '151','164', '2411', '2412', '2414', '2420', '2429']
+_SUPPORTED_SETS = ['15', '55', '58', '58b', '82', '151','164', '2411', '2412', '2414', '2420', '2429', '2467']
 
 
 class UFF:
@@ -387,6 +388,8 @@ class UFF:
             dset = _extract2420(block_data)
         elif self._set_types[int(n)] == 2429:
             dset = _extract2429(block_data)
+        elif self._set_types[int(n)] == 2467:
+            dset = _extract2467(block_data)
         else:
             dset['type'] = self._set_types[int(n)]
             # Unsupported data-set - do nothing


### PR DESCRIPTION
Hey, I needed a library to read UNV files including groups and modified your project a bit:
- 4-line matrices for coordinate systems read correctly in ataset 2420
- changed structure of the 2412 dataset to support rods and enable the use of all officially supported FE descriptors. They are written to dset[41] for example instead of dset['triangle']. This way, all elements are supported, also tetrahedrons. Thic can be changed easilly with a ict for the correct human-readable identifiers.
- implemented R/W functions for dataset 2467 (groups).

Maybe you find those useful. Thanks a lot for your great work!