### PR TITLE
ENH: added uff data structure for each dataset

### DIFF
--- a/pyuff/datasets/dataset_15.py
+++ b/pyuff/datasets/dataset_15.py
@@ -1,29 +1,33 @@
 from os import write
-import os
 import numpy as np
 
 from ..tools import _opt_fields, _parse_header_line, _write_record, check_dict_for_none
-from .. import pyuff
 
-# def _write15(fh, dset):
-#     """Writes coordinate data - data-set 15 - to an open file fh"""
-#     try:
-#         n = len(dset['node_nums'])
-#         # handle optional fields
-#         dset = _opt_fields(dset, {'def_cs': np.asarray([0 for ii in range(0, n)], 'i'),
-#                                         'disp_cs': np.asarray([0 for ii in range(0, n)], 'i'),
-#                                         'color': np.asarray([0 for ii in range(0, n)], 'i')})
-#         # write strings to the file
-#         fh.write('%6i\n%6i%74s\n' % (-1, 15, ' '))
-#         for ii in range(0, n):
-#             fh.write('%10i%10i%10i%10i%13.5e%13.5e%13.5e\n' % (
-#                 dset['node_nums'][ii], dset['def_cs'][ii], dset['disp_cs'][ii], dset['color'][ii],
-#                 dset['x'][ii], dset['y'][ii], dset['z'][ii]))
-#         fh.write('%6i\n' % -1)
-#     except KeyError as msg:
-#         raise Exception('The required key \'' + msg.args[0] + '\' not present when writing data-set #15')
-#     except:
-#         raise Exception('Error writing data-set #15')
+def get_structure_15(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 15
+
+Name:   Nodes
+-----------------------------------------------------------------------
+ 
+             Record 1: FORMAT(4I10,1P3E13.5)
+                       Field 1 -    node label
+                       Field 2 -    definition coordinate system number
+                       Field 3 -    displacement coordinate system number
+                       Field 4 -    color
+                       Field 5-7 -  3 - Dimensional coordinates of node
+                                    in the definition system
+ 
+             NOTE:  Repeat record for each node
+ 
+------------------------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
 
 FORMATS = [
     ['10.0f', '10.0f', '10.0f', '10.0f', '13.5f', '13.5f', '13.5f'],

--- a/pyuff/datasets/dataset_151.py
+++ b/pyuff/datasets/dataset_151.py
@@ -3,7 +3,46 @@ import time
 import os
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
-from .. import pyuff
+
+def get_structure_151(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 151
+
+Name:   Header
+-----------------------------------------------------------------------
+
+Record 1:       FORMAT(80A1)
+                Field 1      -- model file name
+Record 2:       FORMAT(80A1)
+                Field 1      -- model file description
+Record 3:       FORMAT(80A1)
+                Field 1      -- program which created DB
+Record 4:       FORMAT(10A1,10A1,3I10)
+                Field 1      -- date database created (DD-MMM-YY)
+                Field 2      -- time database created (HH:MM:SS)
+                Field 3      -- Version from database
+                Field 4      -- Version from database
+                Field 5      -- File type
+                                =0  Universal
+                                =1  Archive
+                                =2  Other
+Record 5:       FORMAT(10A1,10A1)
+                Field 1      -- date database last saved (DD-MMM-YY)
+                Field 2      -- time database last saved (HH:MM:SS)
+Record 6:       FORMAT(80A1)
+                Field 1      -- program which created universal file
+Record 7:       FORMAT(10A1,10A1)
+                Field 1      -- date universal file written (DD-MMM-YY)
+                Field 2      -- time universal file written (HH:MM:SS)
+
+-----------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
 
 def _write151(fh, dset):
     """Writes dset data - data-set 151 - to an open file fh."""

--- a/pyuff/datasets/dataset_164.py
+++ b/pyuff/datasets/dataset_164.py
@@ -2,7 +2,47 @@ import numpy as np
 import os
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
-from .. import pyuff
+
+def get_structure_164(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 164
+
+Name:   Units
+-----------------------------------------------------------------------
+
+Record 1:       FORMAT(I10,20A1,I10)
+                Field 1      -- units code
+                                = 1 - SI: Meter (newton)
+                                = 2 - BG: Foot (pound f)
+                                = 3 - MG: Meter (kilogram f)
+                                = 4 - BA: Foot (poundal)
+                                = 5 - MM: mm (milli newton)
+                                = 6 - CM: cm (centi newton)
+                                = 7 - IN: Inch (pound f)
+                                = 8 - GM: mm (kilogram f)
+                                = 9 - US: USER_DEFINED
+                Field 2      -- units description (used for
+                                documentation only)
+                Field 3      -- temperature mode
+                                = 1 - absolute
+                                = 2 - relative
+Record 2:       FORMAT(3D25.17)
+                Unit factors for converting universal file units to SI.
+                To convert from universal file units to SI divide by
+                the appropriate factor listed below.
+                Field 1      -- length
+                Field 2      -- force
+                Field 3      -- temperature
+                Field 4      -- temperature offset
+
+-----------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
 
 def _write164(fh, dset):
     """Writes units data - data-set 164 - to an open file fh."""

--- a/pyuff/datasets/dataset_18.py
+++ b/pyuff/datasets/dataset_18.py
@@ -2,6 +2,44 @@ import numpy as np
 
 from ..tools import _opt_fields, _parse_header_line
 
+def get_structure_18(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 18
+
+Name:   Coordinate Systems
+-----------------------------------------------------------------------
+ 
+Record 1:        FORMAT(5I10)
+                 Field 1       -- coordinate system number
+                 Field 2       -- coordinate system type
+                 Field 3       -- reference coordinate system number
+                 Field 4       -- color
+                 Field 5       -- method of definition
+                               = 1 - origin, +x axis, +xz plane
+ 
+Record 2:        FORMAT(20A2)
+                 Field 1       -- coordinate system name
+ 
+Record 3:        FORMAT(1P6E13.5)
+                 Total of 9 coordinate system definition parameters.
+                 Fields 1-3    -- origin of new system specified in
+                                  reference system
+                 Fields 4-6    -- point on +x axis of the new system
+                                  specified in reference system
+                 Fields 7-9    -- point on +xz plane of the new system
+                                  specified in reference system
+ 
+Records 1 thru 3 are repeated for each coordinate system in the model.
+ 
+-----------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
+
 def _extract18(block_data):
     '''Extract local CS definitions -- data-set 18.'''
     dset = {'type': 18}

--- a/pyuff/datasets/dataset_2411.py
+++ b/pyuff/datasets/dataset_2411.py
@@ -2,6 +2,33 @@ import numpy as np
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
 
+def get_structure_2411(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 2411
+
+Name:   Nodes - Double Precision
+----------------------------------------------------------------------------
+
+Record 1:        FORMAT(4I10)
+                 Field 1       -- node label
+                 Field 2       -- export coordinate system number
+                 Field 3       -- displacement coordinate system number
+                 Field 4       -- color
+Record 2:        FORMAT(1P3D25.16)
+                 Fields 1-3    -- node coordinates in the part coordinate
+                                  system
+ 
+Records 1 and 2 are repeated for each node in the model.
+  
+----------------------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
+
 def _write2411(fh, dset):
     try:
         dict = {}

--- a/pyuff/datasets/dataset_2412.py
+++ b/pyuff/datasets/dataset_2412.py
@@ -3,6 +3,47 @@ import itertools
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
 
+def get_structure_2412(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 2412
+
+Name:   Elements
+-----------------------------------------------------------------------
+ 
+Record 1:        FORMAT(6I10)
+                 Field 1       -- element label
+                 Field 2       -- fe descriptor id
+                 Field 3       -- physical property table number
+                 Field 4       -- material property table number
+                 Field 5       -- color
+                 Field 6       -- number of nodes on element
+ 
+Record 2:  *** FOR NON-BEAM ELEMENTS ***
+                 FORMAT(8I10)
+                 Fields 1-n    -- node labels defining element
+ 
+Record 2:  *** FOR BEAM ELEMENTS ONLY ***
+                 FORMAT(3I10)
+                 Field 1       -- beam orientation node number
+                 Field 2       -- beam fore-end cross section number
+                 Field 3       -- beam  aft-end cross section number
+ 
+Record 3:  *** FOR BEAM ELEMENTS ONLY ***
+                 FORMAT(8I10)
+                 Fields 1-n    -- node labels defining element
+ 
+Records 1 and 2 are repeated for each non-beam element in the model.
+Records 1 - 3 are repeated for each beam element in the model.
+ 
+------------------------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
+
 def _write2412(fh, dset):
     try:
         fh.write('%6i\n%6i%74s\n' % (-1, 2412, ' '))

--- a/pyuff/datasets/dataset_2414.py
+++ b/pyuff/datasets/dataset_2414.py
@@ -3,6 +3,544 @@ import math as math
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
 
+def get_structure_2414(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 2414
+
+Name:   Analysis Data
+-----------------------------------------------------------------------
+ 
+Record 1:        FORMAT(1I10)
+                 Field 1       -- Analysis dataset label
+ 
+Record 2:        FORMAT(40A2)
+                 Field 1       -- Analysis dataset name
+
+Record 3:        FORMAT (1I10)
+                 Field 1:      -- Dataset location
+                                   1:    Data at nodes
+                                   2:    Data on elements
+                                   3:    Data at nodes on elements
+                                   5:    Data at points
+
+Record 4:        FORMAT (40A2)
+                 Field 1:      -- ID line 1
+
+Record 5:        FORMAT (40A2)
+                 Field 1:      -- ID line 2
+
+Record 6:        FORMAT (40A2)
+                 Field 1:      -- ID line 3
+
+Record 7:        FORMAT (40A2)
+                 Field 1:      -- ID line 4
+
+Record 8:        FORMAT (40A2)
+                 Field 1:      -- ID line 5
+
+Record 9:        FORMAT (6I10)
+                 Field 1:      -- Model type 
+                                   0:   Unknown
+                                   1:   Structural
+                                   2:   Heat transfer
+                                   3:   Fluid flow
+                 Field 2:      -- Analysis type 
+                                   0:   Unknown
+                                   1:   Static
+                                   2:   Normal mode
+                                   3:   Complex eigenvalue first order
+                                   4:   Transient
+                                   5:   Frequency response
+                                   6:   Buckling
+                                   7:   Complex eigenvalue second order
+                                   9:   Static non-linear
+                 Field 3:      -- Data characteristic     
+                                   0:   Unknown
+                                   1:   Scalar
+                                   2:   3 DOF global translation vector
+                                   3:   6 DOF global translation & rotation 
+                                         vector
+                                   4:   Symmetric global tensor
+                                   6:   Stress resultants
+                 Field 4:      -- Result type
+                                   2:   Stress
+                                   3:   Strain
+                                   4:   Element force
+                                   5:   Temperature
+                                   6:   Heat flux
+                                   7:   Strain energy
+                                   8:   Displacement
+                                   9:   Reaction force
+                                   10:  Kinetic energy
+                                   11:  Velocity
+                                   12:  Acceleration
+                                   13:  Strain energy density
+                                   14:  Kinetic energy density
+                                   15:  Hydro-static pressure
+                                   16:  Heat gradient
+                                   17:  Code checking value
+                                   18:  Coefficient of pressure
+                                   19:  Ply stress
+                                   20:  Ply strain
+                                   21:  Failure index for ply
+                                   22:  Failure index for bonding
+                                   23:  Reaction heat flow
+                                   24:  Stress error density
+                                   25:  Stress variation
+                                   27:  Shell and plate elem stress resultant
+                                   28:  Length
+                                   29:  Area
+                                   30:  Volume
+                                   31:  Mass
+                                   32:  Constraint forces
+                                   34:  Plastic strain
+                                   35:  Creep strain
+                                   36:  Strain energy error
+                                   37:  Dynamic stress at nodes
+                                   38:  Heat Transfer coefficient
+                                   39:  Temperature gradient
+                                   40:  Kinetic energy dissipation rate
+                                   41:  Strain energy error
+                                   42:  Mass flow
+                                   43:  Mass flux
+                                   44:  Heat flow
+                                   45:  View factor
+                                   46:  Heat load
+                                   47:  Stress Component
+                                   93:  Unknown
+                                   94:  Unknown scalar
+                                   95:  Unknown 3DOF vector
+                                   96:  Unknown 6DOF vector
+                                   97:  Unknown symmetric tensor
+                                   98:  Unknown global tensor
+                                   99:  Unknown shell and plate resultant
+                                  301:  Sound Pressure
+                                  302:  Sound Power
+                                  303:  Sound Intensity
+                                  304:  Sound Energy
+                                  305:  Sound Energy Density
+                                >1000:  User defined result type
+                 Field 5:      -- Data type               
+                                   1:   Integer
+                                   2:   Single precision floating point
+                                   4:   Double precision floating point
+                                   5:   Single precision complex
+                                   6:   Double precision complex
+                 Field 6:      -- Number of data values for the data 
+                                  component (NVALDC)
+
+Record 10:       FORMAT (8I10)
+                 Field 1:      -- Integer analysis type specific data (1-8)
+
+Record 11:       FORMAT (8I10)
+                 Field 1:      -- Integer analysis type specific data (9,10)
+
+Record 12:       FORMAT (6E13.5)
+                 Field 1:      -- Real analysis type specific data (1-6)
+
+Record 13:       FORMAT (6E13.5)
+                 Field 1:      -- Real analysis type specific data (7-12)
+
+Note: See chart below for specific analysis type information.
+
+Dataset class: Data at nodes
+
+Record 14:       FORMAT (I10)
+                 Field 1:      -- Node number
+
+Record 15:       FORMAT (6E13.5)
+                 Fields 1-N:   -- Data at this node (NDVAL real or complex
+
+                                                     values)
+          
+                 Note: Records 14 and 15 are repeated for each node.
+
+Dataset class: Data at elements
+
+Record 14:       FORMAT (2I10)
+                 Field 1:      -- Element number
+                 Field 2:      -- Number Of data values For this element(NDVAL)
+ 
+Record 15:       FORMAT (6E13.5)
+                 Fields 1-N:   -- Data on element(NDVAL Real Or Complex Values)
+ 
+ 
+                 Note: Records 14 and 15 are repeated for all elements.
+
+Dataset class: Data at nodes on elements
+
+RECORD 14:       FORMAT (4I10)
+                 Field 1:      -- Element number
+                 Field 2:      -- Data expansion code (IEXP) 
+                                  1: Data present for all nodes
+                                  2: Data present for only 1st node -All other
+                                     nodes the same.
+                 Field 3:      -- Number of nodes on elements (NLOCS)
+                 Field 4:      -- Number of data values per node (NVLOC)
+ 
+RECORD 15:       FORMAT (6E13.5)
+ 
+                 Fields 1-N:   -- Data Values At Node 1 (NVLOC Real Or
+                                  Complex Values)
+
+                 Note:  Records 14 And 15 Are repeated For each Element.  
+   
+                
+                        For Iexp = 1 Record 15 Is repeated NLOCS Times
+ 
+                        For Iexp = 2 Record 15 appears once
+
+Dataset class: Data at points
+
+RECORD 14:       FORMAT (5I10)
+                 Field 1:      -- Element number
+                 Field 2:      -- Data expansion code (IEXP) 
+                                  1: Data present for all points
+                                  2: Data present for only 1st point -All other
+                                     points the same.
+                 Field 3:      -- Number of points on elements (NLOCS)
+                 Field 4:      -- Number of data values per point (NVLOC)
+                 Field 5:      -- Element order
+ 
+RECORD 15:       FORMAT (6E13.5)
+ 
+                 Fields 1-N:   -- Data Values At point 1 (NVLOC Real Or
+                                  Complex Values)
+
+                 Note:  Records 14 And 15 Are repeated For each Element.  
+   
+                
+                        For Iexp = 1 Record 15 Is repeated NLOC Times
+ 
+                        For Iexp = 2 Record 15 appears once          
+
+          Notes:   1.  ID lines may not be blank.  If no information
+                       is required, the word "NONE" must appear in
+                       columns 1-4.
+
+                   2.  The data is store in 
+                       "node-layer-data charateristic" format.
+
+                        Loc1 layer1 component1, Loc1 layer1 component2, ...
+                        Loc1 layer1 componentN, Loc1 layer2 component1, ...
+                        Loc1 Layer2 componentN, ...Loc1 layerN componentN
+                        Loc2 layer1 component1, ...Loc2 layerN componentN
+                        LocN layer1 component1, ...LocN layerN componentN
+
+                   3.  For complex data there Will Be 2*NDVAL data items. The
+                       order is real part for value 1, imaginary part for
+                       value 1, real part for value 2, imaginary part for
+                       value 2, etc.              
+
+                   4.  The order of values for various data
+                       characteristics is:
+
+                       3 DOF Global Vector: X, Y, Z
+                       6 DOF Global Vector: X, Y, Z, Rx, Ry, Rz
+                       Symmetric Global Tensor: Sxx, Sxy, Syy,
+                                                Sxz, Syz, Szz
+
+                       Shell and Plate Element Resultant: Fx, Fy, Fxy,
+                                                          Mx, My, Mxy,
+                                                          Vx, Vy
+
+                   5.  ID line 1 always appears on plots in output
+                       display.
+
+                   6.  If result type is an "UNKNOWN" type,  id line 2
+                       is displayed as data type in output display.
+
+                   7.  Data Characteristic values (Record 9, Field 3)
+                       imply the following values Of NDVALDC (Record 9,
+                       Field 6)
+                             Scalar:                   1
+                             3 DOF Global Vector:      3
+                             6 DOF Global Vector:      6
+                             Symmetric Global Tensor:  6
+                             General Global Tensor:    9   
+                             Shell and Plate Resultant:8    
+                       Since this value can also be derived from the Results
+                       Type (Record 9, Field 4), this is redundant data, and
+                       should be kept consistent. Some data was kept for
+                       compatibility with older files.
+
+                   8.  No entry is NOT the same as a 0. entry: all 0s must
+                       be specified.
+
+                   9.  A direct result of 8 is that if no records 14 and
+                       15 appear for a node or element, this entity has
+                       no data and will not be contoured, etc.
+
+                   10. Dataloaders use the following id line convention:
+
+                        1.   (80A1) MODEL IDENTIFICATION
+                        2.   (80A1) RUN IDENTIFICATION
+                        3.   (80A1) RUN DATE/TIME
+                        4.   (80A1) LOAD CASE NAME
+                        For static:
+
+                        5.   (17H LOAD CASE NUMBER;, I10)
+
+                        For normal mode:
+
+                        5.   (10H MODE SAME, I10, 10H FREQUENCY, E13.5)
+
+                   11. For situations with reduced # DOF'S, use 6 DOF 
+                       translation and rotation with unused values = 0.
+
+                   12. The integer associated data "number retained" will 
+                       =0 unless the result set is created by sorting for 
+                       extremes.  The maximum number of values to retain is 6.
+
+        Specifed values:
+          NDVAL  - Number of data values for the element. 
+          NLOCS  - Number of location on the element data is stored for.
+           NVALDC - Number of values for the data component.
+
+        Derived values: 
+          NLAY   - Number of location through the thickness data is stored for
+                 =  NDVAL / ( NLOCS * NDVALC)
+          NVLOC  - Number of values per location.
+                 =  NLAY * NVALDC
+
+        The following is always true:
+        NDVAL =  NLOCS * NLAY * NVALDC
+
+Dataset class: Data at nodes
+
+                   1.  NLOCS = 1
+                       NLAY  = 1
+                    
+                       NDVAL = NVALDC
+
+                   2.  Typical fortran I/O statements for the data
+                       sections are:
+
+                             READ(LUN,1000)NUM
+                             WRITE
+                        1000 FORMAT (I10)
+                             READ(LUN,1010) (VAL(I),I=1,NDVAL)
+                             WRITE
+                        1010 FORMAT (6E13.5)
+
+                             Where: VAL is real or complex data array
+                                    NUM is element number
+
+Dataset class: Data at elements
+
+                   1.  Data on 2D type elements may have multiple values
+                       through the element thickness.  In these cases:
+                           NLOCS =1
+                               NLAY  =Number of layers of data through the
+                                      thickness.
+                       
+                         NDVAL = NLAY * NVALDC
+
+                       For solid elements: 
+                         NLOCS = 1
+                               NLAY  = 1
+ 
+                         NDVAL = NVALDC
+
+                       The order of the nodes defines an outward normal which 
+                       specifies the order from position 1 to NPOS.
+
+                   2.  Maximum Value For NVALDC Is 9.
+                       No Maximum Value For NDVAL.
+                       No Maximum Value For NLAY.
+
+                   3.  Typical fortran I/O statements for the data
+                       sections are:
+                             READ (LUN, 1000) NUM, NDVAL
+                             WRITE
+                        1000 FORMAT (2I10)
+                             READ (LUN, 1010) (VAL(I),I=1,NDVAL)
+                             WRITE
+                        1010 FORMAT (6E13.5)
+ 
+                             Where:  VAL is real or complex data array
+                                     NUM is element number
+                                                                          
+Dataset class: Data at nodes on elements
+
+                   1.  Data on 2D type elements may have multiple values
+                       through the element thickness.  In these cases:
+                           NLOCS =Number of nodes for the element.
+                               NLAY  =Number of layers of data through the
+                                      thickness.
+                       
+                         NDVAL = NLOCS * NLAY * NVALDC
+
+                       For solid elements: 
+                         NLOCS = Number of nodes for the element.
+                               NLAY  = 1
+ 
+                         NDVAL = NLOCS * NVALDC
+
+                       The order of the nodes defines an outward normal which 
+                       specifies the order from position 1 to NPOS.    
+
+                   2.  Maximum Value For NVALDC Is 9.
+                       No Maximum Value For NDVAL.
+                       No Maximum Value For NLAY.
+
+                   3.  Typical Fortran I/O statements for the data sections
+                       are:
+ 
+                             READ (LUN,1000) NUM, IEXP, NLOCS, NVLOC
+                             WRITE
+                        1000 FORMAT (4I10)
+                       C
+                       C       Process Expansion Code 1
+                       C
+                             IF (IEXP.NE.1) GO TO 20
+                             NSTRT = 1
+                             DO 10 I=1, NLOCS
+                               NSTOP = NSTRT + NVLOC - 1
+                               READ (LUN,1010) (VAL(J),J=NSTRT,STOP)
+                               WRITE
+                        1010   FORMAT (6E13.5)
+                               NSTRT = NSTRT + NVLOC
+                        10   CONTINUE
+                             GO TO 50
+                       C
+                       C       PROCESS EXPANSION CODE 2
+                       C
+                        20   READ (LUN,1010) (VAL(I),I=1,NVLOC)
+                             NOFF = 0
+                             DO 40 I=1,NLOCS
+                               NOFF = NOFF +NVLOC
+                               DO 30 J=1, NVLOC
+                                 VAL (NOFF+J) = VAL(J)
+                        30     CONTINUE
+                        40   CONTINUE
+                       C
+                        50   NDVAL = NVLOC*NLOCS
+ 
+                             Where:    NUM is element number. 
+                                       IEXP is the element expansion code 
+                                       VAL is real or complex data array. 
+                                                     
+
+Dataset class: Data at points
+
+                   1.  Only Tetrahedral elements will be supported.
+
+                   2.  For solid elements: 
+                         NLOCS = Number of points on the element data is stored
+                                 for.  Determined from the element type and 
+                                 order.
+                               NLAY  = 1
+ 
+                         NDVAL = NLOCS * NVALDC
+
+                   3.  Maximum Value For NVALDC Is 9.
+                       No Maximum Value For NDVAL.
+
+                   4.  The element order is equal to the P-order of the element
+
+                   5.  The number of points per element is calculated from
+                       the element order as follows:
+
+                         Number_of_Points = sum(i= 1 to P-Order+1)   
+                                           [sum(j = 1 to i)[1 + i - j) )]]
+
+                   6.  Typical Fortran I/O statements for the data sections
+                       are:
+ 
+                             READ (LUN,1000) NUM, IEXP, NLOCS, NVLOC, IORDER
+                             WRITE
+                        1000 FORMAT (4I10)
+                                          .                               
+                                          .                               
+                                          .                           
+                           (See 3. for Data at Nodes on Elements)
+
+                                        Analysis Type
+
+                                                                          
+  
+                                                                           S
+                                                                           t
+                                                                           a
+                                              C                       C    t
+                                              o           F           o    i
+                                        N     m           r           m    c
+                                        o     p           e           p     
+                                        r     l           q           l    N
+                                        m     e     T                 e    o
+                                        a     x     r     R     B     x    n
+                            U           l           a     e     u     
+                            n     S           E     n     s     c     E    L
+                            k     t     M     i     s     p     k     i    i
+                            n     a     o     g     i     o     l     g    n
+                            o     t     d     e     e     n     i     e    e
+                            w     i     e     n     n     s     n     n    a
+                            n     c     s     1     t     e     g     2    r
+                                                                      
+       Design set ID        X     X     X     X     X     X     X     X    X
+                                                                      
+       Iteration number           X     X                             
+                                                                      
+       Solution set ID      X     X     X     X     X     X     X     X    X
+ I                                                                    
+ N     Boundary condition   X     X     X     X     X     X     X     X    X
+ T                                                                    
+ E     Load set                   X           X     X     X     X     X
+ G                                                                    
+ E     Mode number                      X     X                 X     X
+ R                                                                    
+       Time step number                             X                      X
+                                                                      
+       Frequency number                                   X           
+                                                                      
+       Creation option      X     X     X     X     X     X     X     X    X
+
+       Number retained      X     X     X     X     X     X     X     X    X
+         
+
+                                                                          
+    
+-----------------------------------------------------------------------
+
+       Time                                         X                      X
+                                                                      
+       Frequency                        X                 X           
+                                                                      
+       Eigenvalue                                               X     
+                                                                      
+       Modal Mass                       X                             
+                                                                      
+       Viscous damping                  X                             
+                                                                      
+       Hysteretic damping               X                             
+                                                                      
+ R     Real part eigenvalue                   X                       X
+ E                                                                    
+ A     Imaginary part eingenvalue             X                       X
+ L                                                                    
+       Real part of modal A                   X                        
+       Real part of mass                                              X
+                                                                      
+       Imaginary part of modal A              X                      
+       Imaginary part of mas                                          X
+                                                                      
+       Real part of modal B                   X                        
+       Real part of stiffnes                                          X
+
+       Imaginary part of modal B              X                      
+       Imaginary part of stiffness                                    X
+                                                                          
+    
+-----------------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
+
 def _write2414(fh, dset):
     """
     DS2414_num is iterative number for each DS2414

--- a/pyuff/datasets/dataset_2420.py
+++ b/pyuff/datasets/dataset_2420.py
@@ -2,6 +2,53 @@ import numpy as np
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
 
+def get_structure_2420(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 2420
+
+Name:   Coordinate Systems
+-----------------------------------------------------------------------
+
+Record 1:        FORMAT (2I10)
+                 Field 1       -- Part UID
+
+Record 2:        FORMAT (40A2)
+                 Field 1       -- Part Name
+
+Record 3:        FORMAT (4I10)
+                 Field 1       -- Coordinate System Label
+                 Field 2       -- Coordinate System Type
+                                  = 0, Cartesian
+                                  = 1, Cylindrical
+                                  = 2, Spherical
+                 Field 3       -- Coordinate System Color
+
+Record 4:        FORMAT (40A2)
+                 Field 1       -- Coordinate System Name
+
+Record 5:        FORMAT (1P3D25.16)
+                 Field 1-3     -- Transformation Matrix Row 1
+
+Record 6:        FORMAT (1P3D25.16)
+                 Field 1-3     -- Transformation Matrix Row 2
+
+Record 7:        FORMAT (1P3D25.16)
+                 Field 1-3     -- Transformation Matrix Row 3
+
+Record 8:        FORMAT (1P3D25.16)
+                 Field 1-3     -- Transformation Matrix Row 4
+
+Records 3 thru 8 are repeated for each Coordinate System in the Part.
+
+-----------------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
+
 def _write2420(fh, dset):
     try:
         dict = {'Part_UID': 1,

--- a/pyuff/datasets/dataset_2429.py
+++ b/pyuff/datasets/dataset_2429.py
@@ -3,6 +3,105 @@ import math
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
 
+def get_structure_2429(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 2429
+
+Name:   Permanent Groups
+-----------------------------------------------------------------------
+
+Record 1:        FORMAT(8I10)
+                 Field 1       -- group number
+                 Field 2       -- active constraint set no. for group
+                 Field 3       -- active restraint set no. for group
+                 Field 4       -- active load set no. for group
+                 Field 5       -- active dof set no. for group
+                 Field 6       -- active temperature set no. for group
+                 Field 7       -- active contact set no. for group
+                 Field 8       -- number of entities in group
+
+Record 2:        FORMAT(20A2)
+                 Field 1       -- group name
+
+Record 3-N:      FORMAT(8I10)
+                 Field 1       -- entity type code
+                 Field 2       -- entity tag
+                 Field 3       -- entity type code
+                 Field 4       -- entity tag
+                 Field 5       -- entity type code
+                 Field 6       -- entity tag
+                 Field 7       -- entity type code
+                 Field 8       -- entity tag
+
+Repeat record 3 for all entities as defined by record 1, field 8.
+Records 1 thru n are repeated for each group in the model.
+
+          Permanent group entity type codes
+
+    Entity Type Code        Entity Description
+
+           2                data surface thickness
+           3                force on point
+           4                force on edge
+           5                traction on face
+           6                pressure on face
+           7                nodes
+           8                finite elements
+           9                dof sets, dof entities
+          10                constraint sets, coupled dofs
+          11                constraint sets, mpc equations
+          12                restraint sets, nodal displacements
+          13                restraint sets, nodal temperatures
+          14                load sets, nodal forces
+          15                load sets, nodal temperatures
+          16                load sets, nodal heat sources/sinks
+          17                load sets, face pressures
+          18                load sets, edge pressures
+          19                load sets, face heat fluxes
+          20                load sets, edge heat fluxes
+          21                load sets, face heat convections
+          22                load sets, edge heat convections
+          23                load sets, face heat radiations
+          24                load sets, edge heat radiations
+          25                load sets, element heat generations
+          26                load sets, beam temperatures
+          27                trace lines
+          28                beam force
+          29                beam distributed load
+          30                data surface
+          31                data curve
+          32                displacement on point (restraint)
+          33                displacement on edge (restraint)
+          34                displacement on surface (restraint)
+          35                temperature on point (restraint)
+          36                temperature on edge (restraint) 
+          37                temperature on face (restraint)
+          38                temperature on point (temperature)
+          39                temperature on edge (temperature)
+          40                temperature on face (temperature)
+          41                heat source on point
+          42                heat flux on edge
+          43                convection on edge
+          44                radiation on edge
+          45                heat flux on face
+          46                convection on face
+          47                radiation on face
+          48                geometry contact region
+          49                fe contact region
+          50                contact pair
+          51                kinematic dof on point
+          52                kinematic dof on edge
+          53                kinematic dof on face
+          54-61             geometric grouping entities
+
+-----------------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
 def _write2429(fh, dset):
     try:
         dict = {'active_constraint_set_no_for_group': 0,

--- a/pyuff/datasets/dataset_2467.py
+++ b/pyuff/datasets/dataset_2467.py
@@ -277,7 +277,7 @@ def prepare_2467(
     if type(groups) != list:
          raise TypeError('groups must be in a list, also a single group')
     for item in groups:
-        pyuff.datasets.dataset_2467.prepare_group(
+        prepare_group(
             item['group_number'],
             item['group_name'],
             item['entity_type_code'],

--- a/pyuff/datasets/dataset_2467.py
+++ b/pyuff/datasets/dataset_2467.py
@@ -1,5 +1,12 @@
-"""
-Dataset 2467 (source: https://github.com/victorsndvg/FEconv/blob/master/source/unv/module_dataset_2467.f90)
+import numpy as np
+import math
+
+from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
+
+def get_structure_2467(raw=False):
+    """(source: https://github.com/victorsndvg/FEconv/blob/master/source/unv/module_dataset_2467.f90)"""
+    out = """
+Universal Dataset Number: 2467
 
 Name:   Permanent Groups
 Record 1:        FORMAT(8I10)
@@ -41,12 +48,10 @@ Group_1
         8         3         0         0
     -1
  """
-import numpy as np
-import math
-
-import pyuff.datasets.dataset_2467
-from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
-
+    if raw:
+        return out
+    else:
+        print(out)   
 def _write2467(fh, dset):
     try:
         dict = {'active_constraint_set_no_for_group': 0,

--- a/pyuff/datasets/dataset_55.py
+++ b/pyuff/datasets/dataset_55.py
@@ -1,8 +1,352 @@
 import numpy as np
-import os
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
-from .. import pyuff
+
+def get_structure_55(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 55
+
+Name:   Data at Nodes
+-----------------------------------------------------------------------
+ 
+          RECORD 1:      Format (40A2)
+               FIELD 1:          ID Line 1
+ 
+          RECORD 2:      Format (40A2)
+               FIELD 1:          ID Line 2
+ 
+          RECORD 3:      Format (40A2)
+ 
+               FIELD 1:          ID Line 3
+ 
+          RECORD 4:      Format (40A2)
+               FIELD 1:          ID Line 4
+ 
+          RECORD 5:      Format (40A2)
+               FIELD 1:          ID Line 5
+ 
+          RECORD 6:      Format (6I10)
+ 
+          Data Definition Parameters
+ 
+               FIELD 1: Model Type
+                           0:   Unknown
+                           1:   Structural
+                           2:   Heat Transfer
+                           3:   Fluid Flow
+ 
+               FIELD 2:  Analysis Type
+                           0:   Unknown
+                           1:   Static
+                           2:   Normal Mode
+                           3:   Complex eigenvalue first order
+                           4:   Transient
+                           5:   Frequency Response
+                           6:   Buckling
+                           7:   Complex eigenvalue second order
+ 
+               FIELD 3:  Data Characteristic
+                           0:   Unknown
+                           1:   Scalar
+                           2:   3 DOF Global Translation 
+                                Vector
+                           3:   6 DOF Global Translation 
+                                & Rotation Vector
+                           4:   Symmetric Global Tensor
+                           5:   General Global Tensor
+ 
+               FIELD 4: Specific Data Type
+                           0:   Unknown
+                           1:   General
+                           2:   Stress
+                           3:   Strain
+                           4:   Element Force
+                           5:   Temperature
+                           6:   Heat Flux
+                           7:   Strain Energy
+                           8:   Displacement
+                           9:   Reaction Force
+                           10:   Kinetic Energy
+                           11:   Velocity
+                           12:   Acceleration
+                           13:   Strain Energy Density
+                           14:   Kinetic Energy Density
+                           15:   Hydro-Static Pressure
+                           16:   Heat Gradient
+                           17:   Code Checking Value
+                           18:   Coefficient Of Pressure
+ 
+               FIELD 5:  Data Type
+                           2:   Real
+                           5:   Complex
+ 
+               FIELD 6:  Number Of Data Values Per Node (NDV)
+ 
+ 
+          Records 7 And 8 Are Analysis Type Specific
+ 
+          General Form
+ 
+          RECORD 7:      Format (8I10)
+ 
+               FIELD 1:          Number Of Integer Data Values
+                           1 < Or = Nint < Or = 10
+               FIELD 2:          Number Of Real Data Values
+                           1 < Or = Nrval < Or = 12
+               FIELDS 3-N:       Type Specific Integer Parameters
+ 
+ 
+          RECORD 8:      Format (6E13.5)
+               FIELDS 1-N:       Type Specific Real Parameters
+ 
+ 
+          For Analysis Type = 0, Unknown
+ 
+          RECORD 7:
+ 
+               FIELD 1:   1
+               FIELD 2:   1
+               FIELD 3:   ID Number
+ 
+          RECORD 8:
+ 
+               FIELD 1:   0.0
+ 
+          For Analysis Type = 1, Static
+ 
+          RECORD 7:
+               FIELD 1:    1
+               FIELD 2:    1
+               FIELD 3:    Load Case Number
+ 
+          RECORD 8:
+               FIELD 11:    0.0
+ 
+          For Analysis Type = 2, Normal Mode
+ 
+          RECORD 7:
+ 
+               FIELD 1:    2
+               FIELD 2:    4
+               FIELD 3:    Load Case Number
+               FIELD 4:    Mode Number
+ 
+          RECORD 8:
+               FIELD 1:    Frequency (Hertz)
+               FIELD 2:    Modal Mass
+               FIELD 3:    Modal Viscous Damping Ratio
+               FIELD 4:    Modal Hysteretic Damping Ratio
+ 
+          For Analysis Type = 3, Complex Eigenvalue
+ 
+          RECORD 7:
+               FIELD 1:    2
+               FIELD 2:    6
+               FIELD 3:    Load Case Number
+               FIELD 4:    Mode Number
+ 
+          RECORD 8:
+ 
+               FIELD 1:    Real Part Eigenvalue
+               FIELD 2:    Imaginary Part Eigenvalue
+               FIELD 3:    Real Part Of Modal A
+               FIELD 4:    Imaginary Part Of Modal A
+               FIELD 5:    Real Part Of Modal B
+               FIELD 6:    Imaginary Part Of Modal B
+ 
+ 
+          For Analysis Type = 4, Transient
+ 
+          RECORD 7:
+ 
+               FIELD 1:    2
+               FIELD 2:    1
+               FIELD 3:    Load Case Number
+               FIELD 4:    Time Step Number
+ 
+          RECORD 8:
+               FIELD 1: Time (Seconds)
+ 
+          For Analysis Type = 5, Frequency Response
+ 
+          RECORD 7:
+ 
+               FIELD 1:    2
+               FIELD 2:    1
+               FIELD 3:    Load Case Number
+               FIELD 4:    Frequency Step Number
+ 
+          RECORD 8:
+               FIELD 1:    Frequency (Hertz)
+ 
+          For Analysis Type = 6, Buckling
+ 
+          RECORD 7:
+ 
+               FIELD 1:    1
+               FIELD 2:    1
+               FIELD 3:    Load Case Number
+ 
+          RECORD 8:
+ 
+               FIELD 1: Eigenvalue
+ 
+          RECORD 9:      Format (I10)
+ 
+               FIELD 1:          Node Number
+ 
+          RECORD 10:     Format (6E13.5)
+               FIELDS 1-N:       Data At This Node (NDV Real Or
+                         Complex Values)
+ 
+          Records 9 And 10 Are Repeated For Each Node.
+ 
+          Notes:
+          1        Id Lines May Not Be Blank.  If No Information Is
+                      Required, The Word "None" Must Appear  Columns 1-4.
+ 
+          2        For Complex Data There Will Be 2*Ndv Data Items At Each
+                      Node. The Order Is Real Part For Value 1,  Imaginary
+                      Part For Value 1, Etc.
+          3        The Order Of Values For Various Data  Characteristics
+                      Is:
+                          3 DOF Global Vector:
+                                  X, Y, Z
+
+                          6 DOF Global Vector:
+                                  X, Y, Z,
+                                  Rx, Ry, Rz
+
+                          Symmetric Global Tensor:
+                                  Sxx, Sxy, Syy,
+                                  Sxz, Syz, Szz
+
+                          General Global Tensor:
+                                  Sxx, Syx, Szx,
+                                  Sxy, Syy, Szy,
+                                  Sxz, Syz, Szz
+
+                          Shell And Plate Element Load:
+                                  Fx, Fy, Fxy,
+                                  Mx, My, Mxy,
+                                  Vx, Vy
+ 
+          4        Id Line 1 Always Appears On Plots In Output Display.
+          5        If Specific Data Type Is "Unknown," ID Line 2 Is
+                      Displayed As Data Type In Output Display.
+          6        Typical Fortran I/O Statements For The Data Sections
+                      Are:
+ 
+                                   Read(Lun,1000)Num
+                                   Write
+                          1000 Format (I10)
+                                   Read(Lun,1010) (VAL(I),I=1,NDV)
+                                   Write
+                          1010 format (6e13.5)
+ 
+ 
+                          Where:     Num Is Node Number 
+                                     Val Is Real Or Complex Data  Array
+                                     Ndv Is Number Of Data Values  Per Node
+ 
+          7        Data Characteristic Values Imply The Following Values
+                      Of Ndv:
+                                      Scalar: 1
+                                      3 DOF Global Vector: 3
+                                      6 DOF Global Vector: 6
+                                      Symmetric Global Tensor: 6
+                                      General Global Tensor: 9
+ 
+          8        Data Associated With I-DEAS Test Has The Following
+                      Special Forms of Specific Data Type and ID Line 5.
+
+                   For Record 6 Field 4-Specific Data Type, values 0
+                      through 12 are as defined above.  13 and 15 
+                      through 19 are:
+
+                               13: excitation force
+                               15: pressure
+                               16: mass
+                               17: time
+                               18: frequency
+                               19: rpm
+
+                   The form of ID Line 5 is:
+ 
+                   Format (4I10)
+                   FIELD 1:  Reference Coordinate Label
+
+                   FIELD 2:  Reference Coordinate Direction
+                                1: X Direction
+                               -1: -X Direction
+                                2: Y Direction
+                               -2: -Y Direction
+                                3: Z Direction
+                               -3: -Z Direction
+ 
+                   FIELD 3:  Numerator Signal Code
+                                see Specific Data Type above
+ 
+                   FIELD 4:  Denominator Signal Code
+                                see Specific Data Type above
+
+
+                   Also note that the modal mass in record 8 is calculated
+                   from the parameter table by I-DEAS Test.
+ 
+          9        Any Record With All 0.0's Data Entries Need Not (But
+                      May) Appear.
+ 
+          10       A Direct Result Of 9 Is That If No Records 9 And 10
+                      Appear, All Data For The Data Set Is 0.0.
+ 
+          11       When New Analysis Types Are Added, Record 7 Fields 1
+                      And 2 Are Always > Or = 1 With Dummy Integer And
+                      Real Zero Data If Data Is Not Required. If Complex
+                      Data Is Needed, It Is Treated As Two Real Numbers,
+                      Real Part Followed By Imaginary Point.
+ 
+          12       Dataloaders Use The Following ID Line Convention:
+ 
+                              1.   (80A1) Model
+                                  Identification
+                              2.   (80A1) Run
+                                  Identification
+                              3.   (80A1) Run
+                                  Date/Time
+                              4.   (80A1) Load Case
+                                  Name
+ 
+                          For Static:
+ 
+                              5.   (17h Load Case
+                                  Number;, I10) For
+                                  Normal Mode:
+                              5.   (10h Mode Same,
+                                  I10, 10H Frequency,
+                                  E13.5)
+          13       No Maximum Value For Ndv .
+ 
+          14       Typical Fortran I/O Statements For Processing Records 7
+                      And 8.
+
+                            Read (LUN,1000)NINT,NRVAL,(IPAR(I),I=1,NINT
+                       1000 Format (8I10)
+                            Read (Lun,1010) (RPAV(I),I=1,NRVAL)
+                       1010 Format (6E13.5)
+ 
+          15       For Situations With Reduced # Dof's, Use 3 DOF
+                      Translations Or 6 DOF Translation And Rotation With
+                      Unused Values = 0.
+ 
+----------------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
 
 def _write55(fh, dset):
     """

--- a/pyuff/datasets/dataset_58.py
+++ b/pyuff/datasets/dataset_58.py
@@ -4,7 +4,825 @@ import sys
 import os
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
-from .. import pyuff
+
+def get_structure_58(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 58
+
+Name:   Function at Nodal DOF
+-----------------------------------------------------------------------
+ 
+         Record 1:     Format(80A1)
+                       Field 1    - ID Line 1
+ 
+                                                 NOTE
+ 
+                           ID Line 1 is generally  used  for  the function
+                           description.
+ 
+ 
+         Record 2:     Format(80A1)
+                       Field 1    - ID Line 2
+ 
+         Record 3:     Format(80A1)
+                       Field 1    - ID Line 3
+ 
+                                                 NOTE
+ 
+                           ID Line 3 is generally used to identify when the
+                           function  was  created.  The date is in the form
+                           DD-MMM-YY, and the time is in the form HH:MM:SS,
+                           with a general Format(9A1,1X,8A1).
+ 
+ 
+         Record 4:     Format(80A1)
+                       Field 1    - ID Line 4
+ 
+         Record 5:     Format(80A1)
+                       Field 1    - ID Line 5
+ 
+         Record 6:     Format(2(I5,I10),2(1X,10A1,I10,I4))
+                                  DOF Identification
+                       Field 1    - Function Type
+                                    0 - General or Unknown
+                                    1 - Time Response
+                                    2 - Auto Spectrum
+                                    3 - Cross Spectrum
+                                    4 - Frequency Response Function
+                                    5 - Transmissibility
+                                    6 - Coherence
+                                    7 - Auto Correlation
+                                    8 - Cross Correlation
+                                    9 - Power Spectral Density (PSD)
+                                    10 - Energy Spectral Density (ESD)
+                                    11 - Probability Density Function
+                                    12 - Spectrum
+                                    13 - Cumulative Frequency Distribution
+                                    14 - Peaks Valley
+                                    15 - Stress/Cycles
+                                    16 - Strain/Cycles
+                                    17 - Orbit
+                                    18 - Mode Indicator Function
+                                    19 - Force Pattern
+                                    20 - Partial Power
+                                    21 - Partial Coherence
+                                    22 - Eigenvalue
+                                    23 - Eigenvector
+                                    24 - Shock Response Spectrum
+                                    25 - Finite Impulse Response Filter
+                                    26 - Multiple Coherence
+                                    27 - Order Function
+                       Field 2    - Function Identification Number
+                       Field 3    - Version Number, or sequence number
+                       Field 4    - Load Case Identification Number
+                                    0 - Single Point Excitation
+                       Field 5    - Response Entity Name ("NONE" if unused)
+                       Field 6    - Response Node
+                       Field 7    - Response Direction
+                                     0 - Scalar
+                                     1 - +X Translation       4 - +X Rotation
+                                    -1 - -X Translation      -4 - -X Rotation
+                                     2 - +Y Translation       5 - +Y Rotation
+                                    -2 - -Y Translation      -5 - -Y Rotation
+                                     3 - +Z Translation       6 - +Z Rotation
+                                    -3 - -Z Translation      -6 - -Z Rotation
+                       Field 8    - Reference Entity Name ("NONE" if unused)
+                       Field 9    - Reference Node
+                       Field 10   - Reference Direction  (same as field 7)
+ 
+                                                 NOTE
+ 
+                           Fields 8, 9, and 10 are only relevant if field 4
+                           is zero.
+ 
+ 
+         Record 7:     Format(3I10,3E13.5)
+                                  Data Form
+                       Field 1    - Ordinate Data Type
+                                    2 - real, single precision
+                                    4 - real, double precision
+                                    5 - complex, single precision
+                                    6 - complex, double precision
+                       Field 2    - Number of data pairs for uneven abscissa
+                                    spacing, or number of data values for even
+                                    abscissa spacing
+                       Field 3    - Abscissa Spacing
+                                    0 - uneven
+                                    1 - even (no abscissa values stored)
+                       Field 4    - Abscissa minimum (0.0 if spacing uneven)
+                       Field 5    - Abscissa increment (0.0 if spacing uneven)
+                       Field 6    - Z-axis value (0.0 if unused)
+ 
+         Record 8:     Format(I10,3I5,2(1X,20A1))
+                                  Abscissa Data Characteristics
+                       Field 1    - Specific Data Type
+                                    0 - unknown
+                                    1 - general
+                                    2 - stress
+                                    3 - strain
+                                    5 - temperature
+                                    6 - heat flux
+                                    8 - displacement
+                                    9 - reaction force
+                                    11 - velocity
+                                    12 - acceleration
+                                    13 - excitation force
+                                    15 - pressure
+                                    16 - mass
+                                    17 - time
+                                    18 - frequency
+                                    19 - rpm
+                                    20 - order
+                       Field 2    - Length units exponent
+                       Field 3    - Force units exponent
+                       Field 4    - Temperature units exponent
+ 
+                                                 NOTE
+ 
+                           Fields 2, 3 and  4  are  relevant  only  if the
+                           Specific Data Type is General, or in the case of
+                           ordinates, the response/reference direction is a
+                           scalar, or the functions are being used for
+                           nonlinear connectors in System Dynamics Analysis.
+                           See Addendum 'A' for the units exponent table.
+ 
+                       Field 5    - Axis label ("NONE" if not used)
+                       Field 6    - Axis units label ("NONE" if not used)
+ 
+                                                 NOTE
+ 
+                           If fields  5  and  6  are  supplied,  they take
+                           precendence  over  program  generated labels and
+                           units.
+ 
+         Record 9:     Format(I10,3I5,2(1X,20A1))
+                       Ordinate (or ordinate numerator) Data Characteristics
+ 
+         Record 10:    Format(I10,3I5,2(1X,20A1))
+                       Ordinate Denominator Data Characteristics
+ 
+         Record 11:    Format(I10,3I5,2(1X,20A1))
+                       Z-axis Data Characteristics
+ 
+                                                 NOTE
+ 
+                           Records 9, 10, and 11 are  always  included and
+                           have fields the same as record 8.  If records 10
+                           and 11 are not used, set field 1 to zero.
+ 
+         Record 12:
+                                   Data Values
+ 
+                         Ordinate            Abscissa
+             Case     Type     Precision     Spacing       Format
+           -------------------------------------------------------------
+               1      real      single        even         6E13.5
+               2      real      single       uneven        6E13.5
+               3     complex    single        even         6E13.5
+               4     complex    single       uneven        6E13.5
+               5      real      double        even         4E20.12
+               6      real      double       uneven     2(E13.5,E20.12)
+               7     complex    double        even         4E20.12
+               8     complex    double       uneven      E13.5,2E20.12
+           --------------------------------------------------------------
+ 
+                                          NOTE
+ 
+           See  Addendum  'B'  for  typical  FORTRAN   READ/WRITE
+           statements for each case.
+ 
+ 
+         General Notes:
+ 
+              1.  ID lines may not be blank.  If no  information  is required,
+                  the word "NONE" must appear in columns 1 through 4.
+ 
+              2.  ID line 1 appears on plots in Finite Element Modeling and is
+                  used as the function description in System Dynamics Analysis.
+ 
+              3.  Dataloaders use the following ID line conventions
+                     ID Line 1 - Model Identification
+                     ID Line 2 - Run Identification
+                     ID Line 3 - Run Date and Time
+                     ID Line 4 - Load Case Name
+ 
+              4.  Coordinates codes from MODAL-PLUS and MODALX are decoded into
+                  node and direction.
+ 
+              5.  Entity names used in System Dynamics Analysis prior to I-DEAS
+                  Level 5 have a 4 character maximum. Beginning with Level 5,
+                  entity names will be ignored if this dataset is preceded by
+                  dataset 259. If no dataset 259 precedes this dataset, then the
+                  entity name will be assumed to exist in model bin number 1.
+ 
+              6.  Record 10 is ignored by System Dynamics Analysis unless load
+                  case = 0. Record 11 is always ignored by System Dynamics
+                  Analysis.
+ 
+              7.  In record 6, if the response or reference names are "NONE"
+                  and are not overridden by a dataset 259, but the correspond-
+                  ing node is non-zero, System Dynamics Analysis adds the node
+                  and direction to the function description if space is sufficie
+ 
+              8.  ID line 1 appears on XY plots in Test Data Analysis along
+                  with ID line 5 if it is defined.  If defined, the axis units
+                  labels also appear on the XY plot instead of the normal
+                  labeling based on the data type of the function.
+ 
+              9.  For functions used with nonlinear connectors in System
+                  Dynamics Analysis, the following requirements must be
+                  adhered to:
+ 
+                  a) Record 6: For a displacement-dependent function, the
+                     function type must be 0; for a frequency-dependent
+                     function, it must be 4. In either case, the load case
+                     identification number must be 0.
+ 
+                  b) Record 8: For a displacement-dependent function, the
+                     specific data type must be 8 and the length units
+                     exponent must be 0 or 1; for a frequency-dependent
+                     function, the specific data type must be 18 and the
+                     length units exponent must be 0. In either case, the
+                     other units exponents must be 0.
+ 
+                  c) Record 9: The specific data type must be 13. The
+                     temperature units exponent must be 0. For an ordinate
+                     numerator of force, the length and force units
+                     exponents must be 0 and 1, respectively. For an
+                     ordinate numerator of moment, the length and force
+                     units exponents must be 1 and 1, respectively.
+ 
+                  d) Record 10: The specific data type must be 8 for
+                     stiffness and hysteretic damping; it must be 11
+                     for viscous damping. For an ordinate denominator of
+                     translational displacement, the length units exponent
+                     must be 1; for a rotational displacement, it must
+                     be 0. The other units exponents must be 0.
+ 
+                  e) Dataset 217 must precede each function in order to
+                     define the function's usage (i.e. stiffness, viscous
+                     damping, hysteretic damping).
+ 
+                                       Addendum A
+ 
+         In order to correctly perform units  conversion,  length,  force, and
+         temperature  exponents  must  be  supplied for a specific data type of
+         General; that is, Record 8 Field 1 = 1.  For example, if the function
+         has  the  physical dimensionality of Energy (Force * Length), then the
+         required exponents would be as follows:
+ 
+                 Length = 1
+                 Force = 1          Energy = L * F
+                 Temperature = 0
+ 
+         Units exponents for the remaining specific data types  should not  be
+         supplied.  The following exponents will automatically be used.
+ 
+ 
+                              Table - Unit Exponents
+              -------------------------------------------------------
+               Specific                   Direction
+                        ---------------------------------------------
+                 Data       Translational            Rotational
+                        ---------------------------------------------
+                 Type    Length  Force  Temp    Length  Force  Temp
+              -------------------------------------------------------
+                  0        0       0      0       0       0      0
+                  1             (requires input to fields 2,3,4)
+                  2       -2       1      0      -1       1      0
+                  3        0       0      0       0       0      0
+                  5        0       0      1       0       0      1
+                  6        1       1      0       1       1      0
+                  8        1       0      0       0       0      0
+                  9        0       1      0       1       1      0
+                 11        1       0      0       0       0      0
+                 12        1       0      0       0       0      0
+                 13        0       1      0       1       1      0
+                 15       -2       1      0      -1       1      0
+                 16       -1       1      0       1       1      0
+                 17        0       0      0       0       0      0
+                 18        0       0      0       0       0      0
+                 19        0       0      0       0       0      0
+              --------------------------------------------------------
+ 
+                                          NOTE
+ 
+                 Units exponents for scalar points are defined within
+                 System Analysis prior to reading this dataset.
+ 
+                                       Addendum B
+ 
+         There are 8 distinct  combinations  of  parameters  which  affect the
+         details   of  READ/WRITE  operations.   The  parameters  involved are
+         Ordinate Data Type, Ordinate Data  Precision,  and  Abscissa Spacing.
+         Each  combination  is documented in the examples below.  In all cases,
+         the number of data values (for even abscissa spacing)  or  data pairs
+         (for  uneven  abscissa  spacing)  is NVAL.  The abcissa is always real
+         single precision.  Complex double precision is  handled  by  two real
+         double  precision  variables  (real  part  followed by imaginary part)
+         because most systems do not directly support complex double precision.
+ 
+         CASE 1
+ 
+         REAL
+         SINGLE PRECISION
+         EVEN SPACING
+ 
+           Order of data in file           Y1   Y2   Y3   Y4   Y5   Y6
+                                           Y7   Y8   Y9   Y10  Y11  Y12
+                                                      .
+                                                      .
+                                                      .
+           Input
+ 
+                     REAL Y(6)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 READ(LUN,1000,ERR=  ,END=  )(Y(I),I=1,6)
+                1000 FORMAT(6E13.5)
+                     NPRO=NPRO+6
+                       .
+                       .    code to process these six values
+                       .
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+           Output
+ 
+                     REAL Y(6)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 CONTINUE
+                       .
+                       .    code to set up these six values
+                       .
+                     WRITE(LUN,1000,ERR=  )(Y(I),I=1,6)
+                1000 FORMAT(6E13.5)
+                     NPRO=NPRO+6
+ 
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+         CASE 2
+ 
+         REAL
+         SINGLE PRECISION
+         UNEVEN SPACING
+ 
+           Order of data in file          X1   Y1   X2   Y2   X3   Y3
+                                          X4   Y4   X5   Y5   X6   Y6
+                                           .
+                                           .
+                                           .
+ 
+           Input
+ 
+                     REAL X(3),Y(3)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 READ(LUN,1000,ERR=  ,END=  )(X(I),Y(I),I=1,3)
+                1000 FORMAT(6E13.5)
+                     NPRO=NPRO+3
+                       .
+                       .    code to process these three values
+                       .
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+ 
+           Output
+ 
+                     REAL X(3),Y(3)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 CONTINUE
+                       .
+                       .    code to set up these three values
+                       .
+                     WRITE(LUN,1000,ERR=  )(X(I),Y(I),I=1,3)
+                1000 FORMAT(6E13.5)
+                     NPRO=NPRO+3
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+         CASE 3
+ 
+         COMPLEX
+         SINGLE PRECISION
+         EVEN SPACING
+ 
+           Order of data in file          RY1  IY1  RY2  IY2  RY3  IY3
+                                          RY4  IY4  RY5  IY5  RY6  IY6
+                                           .
+                                           .
+                                           .
+ 
+           Input
+ 
+                     COMPLEX Y(3)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 READ(LUN,1000,ERR=  ,END=  )(Y(I),I=1,3)
+                1000 FORMAT(6E13.5)
+                     NPRO=NPRO+3
+                       .
+                       .    code to process these six values
+                       .
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+ 
+           Output
+ 
+                     COMPLEX Y(3)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 CONTINUE
+                       .
+                       .    code to set up these three values
+                       .
+                     WRITE(LUN,1000,ERR=  )(Y(I),I=1,3)
+                1000 FORMAT(6E13.5)
+                     NPRO=NPRO+3
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+         CASE 4
+ 
+         COMPLEX
+         SINGLE PRECISION
+         UNEVEN SPACING
+ 
+           Order of data in file          X1   RY1  IY1  X2  RY2  IY2
+                                          X3   RY3  IY3  X4  RY4  IY4
+ 
+                                           .
+                                           .
+                                           .
+ 
+           Input
+ 
+                     REAL X(2)
+                     COMPLEX Y(2)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 READ(LUN,1000,ERR=  ,END=  )(X(I),Y(I),I=1,2)
+                1000 FORMAT(6E13.5)
+                     NPRO=NPRO+2
+                       .
+                       .    code to process these two values
+                       .
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+          Output
+ 
+                     REAL X(2)
+                     COMPLEX Y(2)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 CONTINUE
+                       .
+                       .    code to set up these two values
+                       .
+                     WRITE(LUN,1000,ERR=  )(X(I),Y(I),I=1,2)
+                1000 FORMAT(6E13.5)
+                     NPRO=NPRO+2
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+         CASE 5
+ 
+         REAL
+         DOUBLE PRECISION
+         EVEN SPACING
+ 
+           Order of data in file          Y1     Y2     Y3     Y4
+                                          Y5     Y6     Y7     Y8
+                                           .
+                                           .
+                                           .
+           Input
+ 
+                     DOUBLE PRECISION Y(4)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 READ(LUN,1000,ERR=  ,END=  )(Y(I),I=1,4)
+                1000 FORMAT(4E20.12)
+                     NPRO=NPRO+4
+                       .
+                       .    code to process these four values
+                       .
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+ 
+           Output
+ 
+                     DOUBLE PRECISION Y(4)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 CONTINUE
+                       .
+                       .    code to set up these four values
+                       .
+                     WRITE(LUN,1000,ERR=  )(Y(I),I=1,4)
+                1000 FORMAT(4E20.12)
+                     NPRO=NPRO+4
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+         CASE 6
+ 
+         REAL
+         DOUBLE PRECISION
+         UNEVEN SPACING
+ 
+           Order of data in file          X1   Y1     X2   Y2
+                                          X3   Y3     X4   Y4
+                                           .
+                                           .
+                                           .
+           Input
+ 
+                     REAL X(2)
+                     DOUBLE PRECISION Y(2)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 READ(LUN,1000,ERR=  ,END=  )(X(I),Y(I),I=1,2)
+                1000 FORMAT(2(E13.5,E20.12))
+                     NPRO=NPRO+2
+                       .
+                       .    code to process these two values
+                       .
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+           Output
+ 
+                     REAL X(2)
+                     DOUBLE PRECISION Y(2)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 CONTINUE
+                       .
+                       .    code to set up these two values
+                       .
+                     WRITE(LUN,1000,ERR=  )(X(I),Y(I),I=1,2)
+                1000 FORMAT(2(E13.5,E20.12))
+                     NPRO=NPRO+2
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+         CASE 7
+ 
+         COMPLEX
+         DOUBLE PRECISION
+         EVEN SPACING
+ 
+           Order of data in file          RY1    IY1    RY2    IY2
+                                          RY3    IY3    RY4    IY4
+                                           .
+                                           .
+                                           .
+ 
+           Input
+ 
+                     DOUBLE PRECISION Y(2,2)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 READ(LUN,1000,ERR=  ,END=  )((Y(I,J),I=1,2),J=1,2)
+                1000 FORMAT(4E20.12)
+                     NPRO=NPRO+2
+                       .
+                       .    code to process these two values
+                       .
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+           Output
+ 
+                     DOUBLE PRECISION Y(2,2)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 CONTINUE
+                       .
+                       .    code to set up these two values
+                       .
+                     WRITE(LUN,1000,ERR=  )((Y(I,J),I=1,2),J=1,2)
+                1000 FORMAT(4E20.12)
+                     NPRO=NPRO+2
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+         CASE 8
+ 
+         COMPLEX
+         DOUBLE PRECISION
+         UNEVEN SPACING
+ 
+           Order of data in file          X1   RY1    IY1
+                                          X2   RY2    IY2
+                                           .
+                                           .
+                                           .
+           Input
+ 
+                     REAL X
+                     DOUBLE PRECISION Y(2)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 READ(LUN,1000,ERR=  ,END=  )(X,Y(I),I=1,2)
+                1000 FORMAT(E13.5,2E20.12)
+                     NPRO=NPRO+1
+                       .
+                       .    code to process this value
+                       .
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+           Output
+ 
+                     REAL X
+                     DOUBLE PRECISION Y(2)
+                       .
+                       .
+                       .
+                     NPRO=0
+                  10 CONTINUE
+                       .
+                       .    code to set up this value
+                       .
+                     WRITE(LUN,1000,ERR=  )(X,Y(I),I=1,2)
+                1000 FORMAT(E13.5,2E20.12)
+                     NPRO=NPRO+1
+                     IF(NPRO.LT.NVAL)GO TO 10
+                       .
+                       .   continued processing
+                       .
+ 
+-----------------------------------------------------------------------
+The Binary 58 Universal File Format (UFF):
+
+The basic (ASCII) universal file format for data is universal file format
+58.  This format is completely documented by SDRC and a copy of that
+documentation is on the UC-SDRL web site (58.asc). The
+universal file format always begins with two records that are prior to the
+information defined by each universal file format and ends with a record
+that is placed after the information defined by the format.   First of
+all, all records are 80 character ASCII records for the basic universal
+file format. The first and last record are start/stop records and are
+always -1 in the first six columns, right justified (Fortran I6 field
+with -1 in the field).  The second record (Identifier Record) always
+contains the universal file format number in the first 6 columns, right
+justified.
+
+This gives a file structure as follows (where b represent a blank
+character):
+
+bbbb-1
+bbbb58
+...
+...
+...
+bbbb-1
+
+The Binary 58 universal file format was originally developed by UC-SDRL 
+in order to eliminate the need to compress the UFF 58 records and to reduce
+the time required to load the UFF 58 data records.  The Binary 58 universal file
+format yields files that are comparable to compressed files (approximately 3 to
+4 times smaller than the equivalent UFF 58 file).  The Binary 58 universal file 
+format loads approximately 30 to 40 times faster than the equivalent UFF 58 
+file, depending upon the computing environment.  This new format was 
+submitted to SDRC and subsequently adopted as a supported format.
+
+The Binary 58 universal file format uses the same ASCII records at the
+start of each data file as the ASCII dataset 58 but, beginning with
+record 12, the data is stored in binary form rather than the specified
+ASCII format.  The identifier record has the same 58 identifier in the
+first six columns, right justified, but has additional information in
+the rest of the 80 character record that identifies the binary format
+(the size of the binary record, the format of the binary structure, etc.).
+
+    -1
+    58b     x     y          11        zzzz     0     0           0           0
+...
+... (11 ASCII header lines)
+...
+...
+... (zzzz BINARY bytes of data, in format specifed by x and y, above)
+... (interleaved as specified by the ASCII dataset 58)
+...
+    -1
+
+
+When reading or writing a dataset 58b, care must be taken that the
+binary data immediately follows the ASCII header lines and the closing
+'    -1' immediately follows the binary data.  The binary data content
+is written in the same sequence as the ASCII dataset 58 (ie. field
+order sequence).  The field size is NOT used, however the data type
+(int/float/double) content is.  Note: there are no CR/LF characters
+embedded in or following the binary data.
+
+
+=====================================================================
+The Format of 58b ID-Line:
+----------------------------
+
+For the traditional dataset 58 (Function at Nodal DOF), the dataset
+id-line is composed of four spaces followed by "58". This line has been
+enhanced to contain additional information for the binary version of
+dataset 58.
+
+    -1
+    58b     2     2          11        4096     0     0           0           0
+
+     Format (I6,1A1,I6,I6,I12,I12,I6,I6,I12,I12)
+
+              Field 1       - 58  [I6]
+              Field 2       - lowercase b [1A1]
+              Field 3       - Byte Ordering Method [I6]
+                              1 - Little Endian (DEC VMS & ULTRIX, WIN NT)
+                              2 - Big Endian (most UNIX)
+              Field 4       - Floating Point Format [I6]
+                              1 - DEC VMS
+                              2 - IEEE 754 (UNIX)
+                              3 - IBM 5/370
+              Field 5       - number of ASCII lines following  [I12]
+                              11 - for dataset 58
+              Field 6       - number of bytes following ASCII lines  [I12]
+              Fields 7-10   - Not used (fill with zeros)
+
+
+The format of this line should remain constant for any other dataset
+that takes on a binary format in the future.
+
+=====================================================================
+"""
+    if raw:
+        return out
+    else:
+        print(out)   
 
 def _write58(fh, dset, mode='add', _filename=None, force_double=True):
     """Writes function at nodal DOF - data-set 58 - to an open file fh."""

--- a/pyuff/datasets/dataset_82.py
+++ b/pyuff/datasets/dataset_82.py
@@ -2,8 +2,46 @@ import numpy as np
 import os
 
 from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
-from .. import pyuff
 
+def get_structure_82(raw=False):
+    """(source: https://www.ceas3.uc.edu/sdrluff/"""
+    out = """
+Universal Dataset Number: 82
+
+Name:   Tracelines
+-----------------------------------------------------------------------
+ 
+             Record 1: FORMAT(3I10)
+                       Field 1 -    trace line number
+                       Field 2 -    number of nodes defining trace line
+                                    (maximum of 250)
+                       Field 3 -    color
+ 
+             Record 2: FORMAT(80A1)
+                       Field 1 -    Identification line
+ 
+             Record 3: FORMAT(8I10)
+                       Field 1 -    nodes defining trace line
+                               =    > 0 draw line to node
+                               =    0 move to node (a move to the first
+                                    node is implied)
+             Notes: 1) MODAL-PLUS node numbers must not exceed 8000.
+                    2) Identification line may not be blank.
+                    3) Systan only uses the first 60 characters of the
+                       identification text.
+                    4) MODAL-PLUS does not support trace lines longer than
+                       125 nodes.
+                    5) Supertab only uses the first 40 characters of the
+                       identification line for a name.
+                    6) Repeat Datasets for each Trace_Line
+ 
+------------------------------------------------------------------------------
+"""
+
+    if raw:
+        return out
+    else:
+        print(out)   
 
 def _write82(fh, dset):
     """Writes line data - data-set 82 - to an open file fh"""

--- a/pyuff/pyuff.py
+++ b/pyuff/pyuff.py
@@ -7,8 +7,8 @@ This module defines an UFF class to manipulate with the
 UFF (Universal File Format) files, i.e., to read from and write
 to UFF files. Among the variety of UFF formats, only some of the
 formats (data-set types) frequently used in structural dynamics
-are supported: **15, 55, 58, 58b, 82, 151, 164, 2411, 2412, 2414, 2420, 2429, 2467** Data-set **58b**
-is actually a hybrid format [1]_ where the signal is written in the
+are supported: **15, 55, 58, 58b, 82, 151, 164, 2411, 2412, 2414, 2420, 2429, 2467** 
+Data-set **58b** is actually a hybrid format [1]_ where the signal is written in the
 binary form, while the header-part is slightly different from 58 but still in the
 ascii format.
 
@@ -46,19 +46,19 @@ import warnings
 warnings.simplefilter("default")
 
 
-from .datasets.dataset_15 import _write15, _extract15
-from .datasets.dataset_18 import _extract18
-from .datasets.dataset_55 import _write55, _extract55
-from .datasets.dataset_58 import _write58, _extract58
-from .datasets.dataset_82 import _write82, _extract82
-from .datasets.dataset_151 import _write151, _extract151
-from .datasets.dataset_164 import _write164, _extract164
-from .datasets.dataset_2411 import _write2411, _extract2411
-from .datasets.dataset_2412 import _write2412, _extract2412
-from .datasets.dataset_2414 import _write2414, _extract2414
-from .datasets.dataset_2420 import _write2420, _extract2420
-from .datasets.dataset_2429 import _write2429, _extract2429
-from .datasets.dataset_2467 import _write2467, _extract2467
+from .datasets.dataset_15 import _write15, _extract15, get_structure_15
+from .datasets.dataset_18 import _extract18, get_structure_18
+from .datasets.dataset_55 import _write55, _extract55, get_structure_55
+from .datasets.dataset_58 import _write58, _extract58, get_structure_58
+from .datasets.dataset_82 import _write82, _extract82, get_structure_82
+from .datasets.dataset_151 import _write151, _extract151, get_structure_151
+from .datasets.dataset_164 import _write164, _extract164, get_structure_164
+from .datasets.dataset_2411 import _write2411, _extract2411, get_structure_2411
+from .datasets.dataset_2412 import _write2412, _extract2412, get_structure_2412
+from .datasets.dataset_2414 import _write2414, _extract2414, get_structure_2414
+from .datasets.dataset_2420 import _write2420, _extract2420, get_structure_2420
+from .datasets.dataset_2429 import _write2429, _extract2429, get_structure_2429
+from .datasets.dataset_2467 import _write2467, _extract2467, get_structure_2467
 
 _SUPPORTED_SETS = ['15', '55', '58', '58b', '82', '151','164', '2411', '2412', '2414', '2420', '2429', '2467']
 
@@ -453,16 +453,4 @@ class UFF:
 
 
 if __name__ == '__main__':
-    #uff_ascii = UFF('./data/beam.uff')
-    #a = uff_ascii.read_sets(0)
-    #print(a)
-    #prepare_test_55('./data/test_uff55.uff')
-    # uff_ascii = UFF('./data/Artemis export - Geometry RPBC_setup_05_14102016_105117.uff')
-    #uff_ascii = UFF('./data/no_spacing2_UFF58_ascii.uff')
-    #uff_ascii = UFF('./data/mesh_Oros-modal_uff15_uff2412.unv')
-    uff_ascii = UFF('./data/DS2414_disp_file.uff')
-    a = uff_ascii.read_sets(3)
-    for _ in a.keys():
-        if _ != 'data':
-            print(_, ':', a[_])
-    #print(sum(a['data']))
+    pass


### PR DESCRIPTION
I added `get_structure_xy()` methods to each dataset. With this, the structure of a particular dataset is accessible without checking the https://www.ceas3.uc.edu/sdrluff/ webpage and can also be printed from the code, by e.g. using `pyuff.get_structure_58()`. if optional parameter raw=True is used the specification is returned as raw string.