### PR TITLE
read_sets() without loading data

### DIFF
--- a/pyuff/datasets/dataset_58.py
+++ b/pyuff/datasets/dataset_58.py
@@ -1024,7 +1024,9 @@ def _write58(fh, dset, mode='add', _filename=None, force_double=True):
 def _extract58(block_data, header_only=False):
     """
     Extract function at nodal DOF - data-set 58. 
-    If header_only is False, everything will be extracted (Default). Otherwise only the header data will be extracted.
+
+    :param header_only: False (default). If True the header data will be 
+                        extracted, only (useful with large files).
     """
 
 
@@ -1075,7 +1077,11 @@ def _extract58(block_data, header_only=False):
                                                 'z_axis_axis_units_lab']))
         # Body
         # split_data = ''.join(split_data[13:])
-        if not header_only:
+        if header_only:
+            # If not reading data, just set placeholders
+            dset['x'] = None
+            dset['data'] = None
+        else:
             if binary:
                 try:     
                     split_data = b''.join(block_data.splitlines(True)[13:])
@@ -1143,10 +1149,6 @@ def _extract58(block_data, header_only=False):
                     dset['x'] = min_val + np.arange(n_val) * d
                     dset['data'] = values[0:-1:2] + 1.j * values[1::2]
             del values
-        else:
-            # If not reading data, just set placeholders
-            dset['x'] = None
-            dset['data'] = None
     except:
         raise Exception('Error reading data-set #58b')
     return dset

--- a/pyuff/datasets/dataset_58.py
+++ b/pyuff/datasets/dataset_58.py
@@ -1021,10 +1021,10 @@ def _write58(fh, dset, mode='add', _filename=None, force_double=True):
         raise Exception('Error writing data-set #58')
 
 
-def _extract58(block_data, include_all = True):
+def _extract58(block_data, header_only=False):
     """
     Extract function at nodal DOF - data-set 58. 
-    If include_all is True, everything will be extracted. Otherwise only the metadata.
+    If header_only is False, everything will be extracted (Default). Otherwise only the header data will be extracted.
     """
 
 
@@ -1075,7 +1075,7 @@ def _extract58(block_data, include_all = True):
                                                 'z_axis_axis_units_lab']))
         # Body
         # split_data = ''.join(split_data[13:])
-        if include_all:
+        if not header_only:
             if binary:
                 try:     
                     split_data = b''.join(block_data.splitlines(True)[13:])

--- a/pyuff/pyuff.py
+++ b/pyuff/pyuff.py
@@ -232,16 +232,18 @@ class UFF:
 
     def read_sets(self, setn=None, header_only=False):
         """
-        Reads sets from the list or array ``setn``. If ``setn=None``, all
-        sets are read (default). Sets are numbered starting at 0, ending at
-        n-1. If ``header_only=False``, then all data will be read (default),
-        otherwise only header data is read when applicable. The method returns
-        a list of dset dictionaries - as many dictionaries as there are sets. 
-        Unknown data-sets are returned empty.
+        Reads sets.
         
+        The method returns a list of dset dictionaries - as many dictionaries as there are sets. 
+        Unknown data-sets are returned empty.
         User must be sure that, since the last reading/writing/refreshing,
         the data has not changed by some other means than through the
         UFF object.
+        
+        :param setn: None(default), all sets are read in None (default). 
+                     If a number is given, then only a particular set is read. 
+        :param header_only: False (default), if True header is read, only
+                     This usefull for large files.         
         """
         dset = []
         if setn is None:
@@ -258,7 +260,7 @@ class UFF:
                 raise Exception('Cannot read from the file: ' + self._filename)
         try:
             for ii in read_range:
-                dset.append(self._read_set(ii, header_only))
+                dset.append(self._read_set(ii, header_only=header_only))
         except Exception as msg:
             if hasattr(msg, 'value'):
                 raise Exception('Error when reading ' + str(ii) + '-th data-set: ' + msg.value)
@@ -311,10 +313,15 @@ class UFF:
     def _read_set(self, n, header_only=False):
         """
         Reads n-th set from UFF file. 
+
         n can be an integer between 0 and n_sets-1. 
+        
         User must be sure that, since the last reading/writing/refreshing, 
         the data has not changed by some other means than through the
         UFF object. The method returns dset dictionary.
+
+        :param header_only: False (default), if True header is read, only
+                This usefull for large files.    
         """
         
         dset = {}
@@ -353,7 +360,7 @@ class UFF:
         elif self._set_types[int(n)] == 55:
             dset = _extract55(block_data)
         elif self._set_types[int(n)] == 58:
-            dset = _extract58(block_data, header_only) # only added lazy load option for 58 so far...
+            dset = _extract58(block_data, header_only=header_only)
         elif self._set_types[int(n)] == 82:
             dset = _extract82(block_data)
         elif self._set_types[int(n)] == 151:

--- a/pyuff/pyuff.py
+++ b/pyuff/pyuff.py
@@ -230,13 +230,14 @@ class UFF:
                 fh.close()
                 return self._refreshed
 
-    def read_sets(self, setn=None):
+    def read_sets(self, setn=None, include_all=True):
         """
         Reads sets from the list or array ``setn``. If ``setn=None``, all
         sets are read (default). Sets are numbered starting at 0, ending at
-        n-1. The method returns a list of dset dictionaries - as
-        many dictionaries as there are sets. Unknown data-sets are returned
-        empty.
+        n-1. If ``include_all=True``, then all data will be read (default),
+        otherwise only minimal data is read when applicable. The method returns
+        a list of dset dictionaries - as many dictionaries as there are sets. 
+        Unknown data-sets are returned empty.
         
         User must be sure that, since the last reading/writing/refreshing,
         the data has not changed by some other means than through the
@@ -257,7 +258,7 @@ class UFF:
                 raise Exception('Cannot read from the file: ' + self._filename)
         try:
             for ii in read_range:
-                dset.append(self._read_set(ii))
+                dset.append(self._read_set(ii, include_all))
         except Exception as msg:
             if hasattr(msg, 'value'):
                 raise Exception('Error when reading ' + str(ii) + '-th data-set: ' + msg.value)
@@ -307,7 +308,7 @@ class UFF:
         else:
             raise Exception('Unknown mode: ' + mode)
 
-    def _read_set(self, n):
+    def _read_set(self, n, include_all=True):
         """
         Reads n-th set from UFF file. 
         n can be an integer between 0 and n_sets-1. 
@@ -352,7 +353,7 @@ class UFF:
         elif self._set_types[int(n)] == 55:
             dset = _extract55(block_data)
         elif self._set_types[int(n)] == 58:
-            dset = _extract58(block_data)
+            dset = _extract58(block_data, include_all) # only added lazy load option for 58 so far...
         elif self._set_types[int(n)] == 82:
             dset = _extract82(block_data)
         elif self._set_types[int(n)] == 151:

--- a/pyuff/pyuff.py
+++ b/pyuff/pyuff.py
@@ -230,12 +230,12 @@ class UFF:
                 fh.close()
                 return self._refreshed
 
-    def read_sets(self, setn=None, include_all=True):
+    def read_sets(self, setn=None, header_only=False):
         """
         Reads sets from the list or array ``setn``. If ``setn=None``, all
         sets are read (default). Sets are numbered starting at 0, ending at
-        n-1. If ``include_all=True``, then all data will be read (default),
-        otherwise only minimal data is read when applicable. The method returns
+        n-1. If ``header_only=False``, then all data will be read (default),
+        otherwise only header data is read when applicable. The method returns
         a list of dset dictionaries - as many dictionaries as there are sets. 
         Unknown data-sets are returned empty.
         
@@ -258,7 +258,7 @@ class UFF:
                 raise Exception('Cannot read from the file: ' + self._filename)
         try:
             for ii in read_range:
-                dset.append(self._read_set(ii, include_all))
+                dset.append(self._read_set(ii, header_only))
         except Exception as msg:
             if hasattr(msg, 'value'):
                 raise Exception('Error when reading ' + str(ii) + '-th data-set: ' + msg.value)
@@ -308,7 +308,7 @@ class UFF:
         else:
             raise Exception('Unknown mode: ' + mode)
 
-    def _read_set(self, n, include_all=True):
+    def _read_set(self, n, header_only=False):
         """
         Reads n-th set from UFF file. 
         n can be an integer between 0 and n_sets-1. 
@@ -353,7 +353,7 @@ class UFF:
         elif self._set_types[int(n)] == 55:
             dset = _extract55(block_data)
         elif self._set_types[int(n)] == 58:
-            dset = _extract58(block_data, include_all) # only added lazy load option for 58 so far...
+            dset = _extract58(block_data, header_only) # only added lazy load option for 58 so far...
         elif self._set_types[int(n)] == 82:
             dset = _extract82(block_data)
         elif self._set_types[int(n)] == 151:

--- a/tests/test_58.py
+++ b/tests/test_58.py
@@ -6,6 +6,7 @@ sys.path.insert(0, my_path + '/../')
 import pyuff
 
 def test_read_write_read_given_data():
+    test_read_write_read_given_data_base('./data/sample_dataset58_psd.uff', header_only=True)
     test_read_write_read_given_data_base('./data/sample_dataset58_psd.uff', force_double=False)
     test_read_write_read_given_data_base('./data/time-history-not-all-columns-filled.uff')
     test_read_write_read_given_data_base('./data/Artemis export - data and dof 05_14102016_105117.uff')
@@ -16,7 +17,7 @@ def test_read_write_read_given_data():
     test_read_write_read_given_data_base('./data/no_spacing2_UFF58_ascii.uff',data_at_the_end)
     test_read_write_read_given_data_base('./data/sample_dataset58_psd.uff')
 
-def test_read_write_read_given_data_base(file='', data_at_the_end=None, force_double=True):
+def test_read_write_read_given_data_base(file='', data_at_the_end=None, force_double=True, header_only=False):
     if file=='':
         return
     #read from file
@@ -36,7 +37,7 @@ def test_read_write_read_given_data_base(file='', data_at_the_end=None, force_do
 
     #read back
     uff_read = pyuff.UFF(save_to_file)
-    b = uff_read.read_sets(0)
+    b = uff_read.read_sets(setn=0, header_only=header_only)
 
     if os.path.exists(save_to_file):
         os.remove(save_to_file)
@@ -53,17 +54,24 @@ def test_read_write_read_given_data_base(file='', data_at_the_end=None, force_do
     #print(a['n_bytes'], b['n_bytes'])
     for k in numeric_keys:
         print('Testing: ', k)
-        np.testing.assert_array_almost_equal(a[k], b[k], decimal=3)
+        if header_only and k in ['data','x']:
+            np.testing.assert_equal(b[k], None)
+        else:
+            np.testing.assert_array_almost_equal(a[k], b[k], decimal=3)
     for k in string_keys:
         print('Testing string: ', k, a[k])
         np.testing.assert_string_equal(a[k], b[k])
 
-    print('Testing data: ')
-    np.testing.assert_array_almost_equal(a['data'], b['data'])
 
-    if data_at_the_end is not None:
-        print('Testing last data line: ')
-        np.testing.assert_array_almost_equal(a['data'][-len(data_at_the_end):], data_at_the_end)
+    if header_only:
+        pass
+    else:
+        print('Testing data: ')
+        np.testing.assert_array_almost_equal(a['data'], b['data'])
+
+        if data_at_the_end is not None:
+            print('Testing last data line: ')
+            np.testing.assert_array_almost_equal(a['data'][-len(data_at_the_end):], data_at_the_end)
 
 
 


### PR DESCRIPTION
Hi. I modified read_sets(), _read_set() and _extract58() to give option to load metadata only (for dataset 58). I am not as familiar with the other datasets so I didnt add the functionality to them. default is to load all datasets as normal for backwards compatibility.
 
Thanks,