### PR TITLE
resolved wrong dataset separator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyuff"
-version = "2.5.0"
+version = "2.5.1"
 authors = [{name = "Primož Čermelj, Janko Slavič", email = "janko.slavic@fs.uni-lj.si"}]
 maintainers = [{name = "Janko Slavič et al.", email = "janko.slavic@fs.uni-lj.si"}]
 license = "MIT"

--- a/pyuff/__init__.py
+++ b/pyuff/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 from .pyuff import *
 from .datasets import *
 

--- a/pyuff/datasets/dataset_58.py
+++ b/pyuff/datasets/dataset_58.py
@@ -1090,11 +1090,13 @@ def _extract58(block_data, header_only=False):
                     else:
                         bo = '>'
                     if (dset['ord_data_type'] == 2) or (dset['ord_data_type'] == 5):
-                        # single precision - 4 bytes
-                        values = np.asarray(struct.unpack('%c%sf' % (bo, int(len(split_data) / 4)), split_data), 'd')
+                        # single precision - 4 bytes, note: sometimes split_data wrongly contains CR/LF and 
+                        # therefore the length of split_data is not divisible by 4
+                        values = np.asarray(struct.unpack('%c%sf' % (bo, int(len(split_data) / 4)), split_data[:(len(split_data) // 4)*4]), 'd')
                     else:
-                        # double precision - 8 bytes
-                        values = np.asarray(struct.unpack('%c%sd' % (bo, int(len(split_data) / 8)), split_data), 'd')
+                        # double precision - 8 bytes, note: sometimes split_data wrongly contains CR/LF and 
+                        # therefore the length of split_data is not divisible by 8
+                        values = np.asarray(struct.unpack('%c%sd' % (bo, int(len(split_data) / 8)), split_data[:(len(split_data) // 8)*8]), 'd')
                 except:
                     raise Exception('Potentially wrong data format (common with binary files from some commercial softwares). Try using pyuff.fix_58b() to fix your file. For more information, see https://github.com/ladisk/pyuff/issues/61')
             else:


### PR DESCRIPTION
The file "dataset58b_with_wrong_CRLF_before-1.uff" contains wrong use of dataset separator. In dataset 58b the end of data should not end with CRLF as is the case in this file. The solution is described in this issue: https://github.com/ladisk/pyuff/issues/88#issuecomment-2869850934

