### PR TITLE
Add dataset 18 (Coordinate Systems) write support

### DIFF
--- a/pyuff/datasets/__init__.py
+++ b/pyuff/datasets/__init__.py
@@ -1,4 +1,5 @@
 from .dataset_15 import prepare_15
+from .dataset_18 import prepare_18
 from .dataset_55 import prepare_55
 from .dataset_58 import prepare_58
 from .dataset_82 import prepare_82

--- a/pyuff/datasets/dataset_18.py
+++ b/pyuff/datasets/dataset_18.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from ..tools import _opt_fields, _parse_header_line
+from ..tools import _opt_fields, _parse_header_line, check_dict_for_none
+
 
 def get_structure_18(raw=False):
     """(source: https://www.ceas3.uc.edu/sdrluff/"""
@@ -9,7 +10,7 @@ Universal Dataset Number: 18
 
 Name:   Coordinate Systems
 -----------------------------------------------------------------------
- 
+
 Record 1:        FORMAT(5I10)
                  Field 1       -- coordinate system number
                  Field 2       -- coordinate system type
@@ -17,10 +18,10 @@ Record 1:        FORMAT(5I10)
                  Field 4       -- color
                  Field 5       -- method of definition
                                = 1 - origin, +x axis, +xz plane
- 
+
 Record 2:        FORMAT(20A2)
                  Field 1       -- coordinate system name
- 
+
 Record 3:        FORMAT(1P6E13.5)
                  Total of 9 coordinate system definition parameters.
                  Fields 1-3    -- origin of new system specified in
@@ -29,16 +30,48 @@ Record 3:        FORMAT(1P6E13.5)
                                   specified in reference system
                  Fields 7-9    -- point on +xz plane of the new system
                                   specified in reference system
- 
+
 Records 1 thru 3 are repeated for each coordinate system in the model.
- 
+
 -----------------------------------------------------------------
 """
 
     if raw:
         return out
     else:
-        print(out)   
+        print(out)
+
+
+def _write18(fh, dset):
+    """Writes dset data - data-set 18 - to an open file fh."""
+    try:
+        n = len(dset['cs_num'])
+        dset = _opt_fields(dset, {
+            'cs_type': np.zeros(n, dtype=int),
+            'color': np.zeros(n, dtype=int),
+            'method': np.ones(n, dtype=int),
+            'cs_name': [''] * n,
+        })
+        fh.write('%6i\n%6i%74s\n' % (-1, 18, ' '))
+        for i in range(n):
+            fh.write('%10i%10i%10i%10i%10i\n' % (
+                int(dset['cs_num'][i]),
+                int(dset['cs_type'][i]),
+                int(dset['ref_cs_num'][i]),
+                int(dset['color'][i]),
+                int(dset['method'][i])))
+            fh.write('%-40s\n' % dset['cs_name'][i])
+            fh.write('%13.5e%13.5e%13.5e%13.5e%13.5e%13.5e\n' % (
+                dset['ref_o'][i][0], dset['ref_o'][i][1], dset['ref_o'][i][2],
+                dset['x_point'][i][0], dset['x_point'][i][1], dset['x_point'][i][2]))
+            fh.write('%13.5e%13.5e%13.5e\n' % (
+                dset['xz_point'][i][0], dset['xz_point'][i][1], dset['xz_point'][i][2]))
+        fh.write('%6i\n' % -1)
+    except KeyError as msg:
+        raise Exception('The required key \'' + msg.args[0] + '\' not present when writing data-set #18')
+    except:
+        raise Exception('Error writing data-set #18')
+
 
 def _extract18(block_data):
     '''Extract local CS definitions -- data-set 18.'''
@@ -50,18 +83,16 @@ def _extract18(block_data):
         rec_1 = np.array(list(map(float, ''.join(split_data[2::4]).split())))
 
         dset['cs_num'] = rec_1[::5]
-        # removed - clutter
-        # dset['cs_type'] = rec_1[1::5]
+        dset['cs_type'] = rec_1[1::5]
         dset['ref_cs_num'] = rec_1[2::5]
-        # left out here are the parameters color and definition type
+        dset['color'] = rec_1[3::5]
+        dset['method'] = rec_1[4::5]
 
         # -- Get Record 2
-        # removed because clutter
-        # dset['cs_name'] = split_data[3::4]
+        dset['cs_name'] = [s.strip() for s in split_data[3::4]]
 
         # -- Get Record 31 and 32
         # ... these are the origins of cs defined in ref
-        #             rec_31 = np.array(list(map(float, ''.join(split_data[4::4]).split())))
         line_data = ''.join(split_data[4::4])
         rec_31 = [float(line_data[i * 13:(i + 1) * 13]) for i in range(int(len(line_data) / 13))]
         dset['ref_o'] = np.vstack((np.array(rec_31[::6]),
@@ -76,7 +107,6 @@ def _extract18(block_data):
         # ... these are the points on the xz plane
         line_data = ''.join(split_data[5::4])
         rec_32 = [float(line_data[i * 13:(i + 1) * 13]) for i in range(int(len(line_data) / 13))]
-        #             rec_32 = np.array(list(map(float, ''.join(split_data[5::4]).split())))
         dset['xz_point'] = np.vstack((np.array(rec_32[::3]),
                                         np.array(rec_32[1::3]),
                                         np.array(rec_32[2::3]))).transpose()
@@ -85,3 +115,68 @@ def _extract18(block_data):
     return dset
 
 
+def prepare_18(
+        cs_num=None,
+        cs_type=None,
+        ref_cs_num=None,
+        color=None,
+        method=None,
+        cs_name=None,
+        ref_o=None,
+        x_point=None,
+        xz_point=None,
+        return_full_dict=False):
+    """Name: Coordinate Systems
+
+    R-Record, F-Field
+
+    :param cs_num: R1 F1, Coordinate system number (array of int)
+    :param cs_type: R1 F2, Coordinate system type (array of int)
+    :param ref_cs_num: R1 F3, Reference coordinate system number (array of int)
+    :param color: R1 F4, Color (array of int)
+    :param method: R1 F5, Method of definition (array of int, 1=origin+x+xz)
+    :param cs_name: R2 F1, Coordinate system name (list of str)
+    :param ref_o: R3 F1-3, Origin of new system in reference system (Nx3 array)
+    :param x_point: R3 F4-6, Point on +x axis in reference system (Nx3 array)
+    :param xz_point: R3 F7-9, Point on +xz plane in reference system (Nx3 array)
+    :param return_full_dict: If True full dict with all keys is returned, else only specified arguments are included
+
+    **Test prepare_18**
+
+    >>> import pyuff
+    >>> import os
+    >>> save_to_file = 'test_pyuff'
+    >>> dataset = pyuff.prepare_18(
+    >>>     cs_num=[1, 2],
+    >>>     cs_type=[0, 0],
+    >>>     ref_cs_num=[0, 0],
+    >>>     color=[1, 1],
+    >>>     method=[1, 1],
+    >>>     cs_name=['CS1', 'CS2'],
+    >>>     ref_o=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+    >>>     x_point=[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+    >>>     xz_point=[[0.0, 0.0, 1.0], [1.0, 0.0, 1.0]])
+    >>> if save_to_file:
+    >>>     if os.path.exists(save_to_file):
+    >>>         os.remove(save_to_file)
+    >>>     uffwrite = pyuff.UFF(save_to_file)
+    >>>     uffwrite._write_set(dataset, 'add')
+    >>> dataset
+    """
+    dataset = {
+        'type': 18,
+        'cs_num': cs_num,
+        'cs_type': cs_type,
+        'ref_cs_num': ref_cs_num,
+        'color': color,
+        'method': method,
+        'cs_name': cs_name,
+        'ref_o': ref_o,
+        'x_point': x_point,
+        'xz_point': xz_point,
+    }
+
+    if return_full_dict is False:
+        dataset = check_dict_for_none(dataset)
+
+    return dataset

--- a/pyuff/pyuff.py
+++ b/pyuff/pyuff.py
@@ -47,7 +47,7 @@ warnings.simplefilter("default")
 
 
 from .datasets.dataset_15 import _write15, _extract15, get_structure_15
-from .datasets.dataset_18 import _extract18, get_structure_18
+from .datasets.dataset_18 import _write18, _extract18, get_structure_18
 from .datasets.dataset_55 import _write55, _extract55, get_structure_55
 from .datasets.dataset_58 import _write58, _extract58, get_structure_58, fix_58b
 from .datasets.dataset_82 import _write82, _extract82, get_structure_82
@@ -62,7 +62,7 @@ from .datasets.dataset_2420 import _write2420, _extract2420, get_structure_2420
 from .datasets.dataset_2429 import _write2429, _extract2429, get_structure_2429
 from .datasets.dataset_2467 import _write2467, _extract2467, get_structure_2467
 
-_SUPPORTED_SETS = ['15', '55', '58', '58b', '82', '151', '164', '1858', '2400', '2411', '2412', '2414', '2420', '2429', '2467']
+_SUPPORTED_SETS = ['15', '18', '55', '58', '58b', '82', '151', '164', '1858', '2400', '2411', '2412', '2414', '2420', '2429', '2467']
 
 
 class UFF:
@@ -367,7 +367,7 @@ class UFF:
         if self._set_types[int(n)] == 15:
             dset = _extract15(block_data)
         elif self._set_types[int(n)] == 18:
-            dset = _extract18(block_data)  # TEMP ADD
+            dset = _extract18(block_data)
         elif self._set_types[int(n)] == 55:
             dset = _extract55(block_data)
         elif self._set_types[int(n)] == 58:
@@ -443,6 +443,8 @@ class UFF:
 
             if set_type == 15:
                 _write15(fh, dset)
+            elif set_type == 18:
+                _write18(fh, dset)
             elif set_type == 55:
                 _write55(fh, dset)
             elif set_type == 58:

--- a/tests/test_18.py
+++ b/tests/test_18.py
@@ -1,0 +1,104 @@
+import numpy as np
+import sys, os
+my_path = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, my_path + '/../')
+
+import pyuff
+
+
+def test_prepare_18():
+    dataset = pyuff.prepare_18(
+        cs_num=[1, 2],
+        cs_type=[0, 0],
+        ref_cs_num=[0, 0],
+        color=[1, 1],
+        method=[1, 1],
+        cs_name=['CS1', 'CS2'],
+        ref_o=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+        x_point=[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+        xz_point=[[0.0, 0.0, 1.0], [1.0, 0.0, 1.0]])
+
+    assert dataset['type'] == 18
+    assert dataset['cs_num'] == [1, 2]
+    assert dataset['cs_type'] == [0, 0]
+    assert dataset['ref_cs_num'] == [0, 0]
+    assert dataset['color'] == [1, 1]
+    assert dataset['method'] == [1, 1]
+    assert dataset['cs_name'] == ['CS1', 'CS2']
+    assert dataset['ref_o'] == [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+    assert dataset['x_point'] == [[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]
+    assert dataset['xz_point'] == [[0.0, 0.0, 1.0], [1.0, 0.0, 1.0]]
+
+    # empty dict test
+    x = pyuff.prepare_18()
+    assert 'type' in x
+    assert x['type'] == 18
+
+
+def test_read_18():
+    uff_file = pyuff.UFF('./data/TestLab 161 164 18 15 82.uff')
+    sets = uff_file.read_sets()
+    dset = [s for s in sets if s['type'] == 18][0]
+
+    assert dset['cs_num'][0] == 1.0
+    assert dset['ref_cs_num'][0] == 0.0
+    assert dset['cs_type'][0] == 0.0
+    assert dset['color'][0] == 8.0
+    assert dset['method'][0] == 1.0
+    assert dset['cs_name'][0].strip() == 'SYS1'
+    np.testing.assert_array_almost_equal(dset['ref_o'][0], [-2.4, -0.95, 0.0], decimal=5)
+    np.testing.assert_array_almost_equal(dset['x_point'][0], [-3.4, -0.95, -8.74228e-08], decimal=5)
+    np.testing.assert_array_almost_equal(dset['xz_point'][0], [-3.4, -0.95, -1.0], decimal=5)
+    assert len(dset['cs_num']) == 36
+
+
+def test_write_read_18():
+    save_to_file = './data/temp18.uff'
+    if os.path.exists(save_to_file):
+        os.remove(save_to_file)
+
+    dataset = pyuff.prepare_18(
+        cs_num=[1, 2],
+        cs_type=[0, 1],
+        ref_cs_num=[0, 1],
+        color=[8, 4],
+        method=[1, 1],
+        cs_name=['SYS1', 'SYS2'],
+        ref_o=[[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]],
+        x_point=[[1.0, 0.0, 0.0], [2.0, 2.0, 3.0]],
+        xz_point=[[0.0, 0.0, 1.0], [1.0, 2.0, 4.0]])
+
+    uffwrite = pyuff.UFF(save_to_file)
+    uffwrite._write_set(dataset, 'add')
+
+    uff_read = pyuff.UFF(save_to_file)
+    b = uff_read.read_sets(0)
+
+    if os.path.exists(save_to_file):
+        os.remove(save_to_file)
+
+    assert b['type'] == 18
+    assert b['cs_num'][0] == 1.0
+    assert b['cs_num'][1] == 2.0
+    assert b['cs_type'][0] == 0.0
+    assert b['cs_type'][1] == 1.0
+    assert b['ref_cs_num'][0] == 0.0
+    assert b['ref_cs_num'][1] == 1.0
+    assert b['color'][0] == 8.0
+    assert b['color'][1] == 4.0
+    assert b['method'][0] == 1.0
+    assert b['method'][1] == 1.0
+    assert b['cs_name'][0].strip() == 'SYS1'
+    assert b['cs_name'][1].strip() == 'SYS2'
+    np.testing.assert_array_almost_equal(b['ref_o'][0], [0.0, 0.0, 0.0], decimal=5)
+    np.testing.assert_array_almost_equal(b['ref_o'][1], [1.0, 2.0, 3.0], decimal=5)
+    np.testing.assert_array_almost_equal(b['x_point'][0], [1.0, 0.0, 0.0], decimal=5)
+    np.testing.assert_array_almost_equal(b['x_point'][1], [2.0, 2.0, 3.0], decimal=5)
+    np.testing.assert_array_almost_equal(b['xz_point'][0], [0.0, 0.0, 1.0], decimal=5)
+    np.testing.assert_array_almost_equal(b['xz_point'][1], [1.0, 2.0, 4.0], decimal=5)
+
+
+if __name__ == '__main__':
+    test_prepare_18()
+    test_read_18()
+    test_write_read_18()


### PR DESCRIPTION
 Closes #90

  Dataset 18 (Coordinate Systems) previously had read-only support with several fields skipped. This PR adds
  full write support and exposes all fields.

  **Changes to `_extract18`:**
  - Expose previously skipped fields: `cs_type`, `color`, `method`, `cs_name`
  - Strip trailing whitespace from `cs_name` on read for round-trips

  **New functions:**
  - `_write18()` — writes coordinate system data in UFF format (Records 1–3)
  - `prepare_18()` — helper function consistent with other dataset prepare functions

  ## Tests
  - `test_prepare_18` — verifies all fields are stored correctly, empty dict case
  - `test_read_18` — reads 36 coordinate systems from real `TestLab 161 164 18 15 82.uff` file, verifies all fields
  including newly exposed ones
  - `test_write_read_18` — full round-trip write/read with 2 coordinate systems, verifies all fields